### PR TITLE
Add simple login page

### DIFF
--- a/socialdistribution/forms/signup_form.py
+++ b/socialdistribution/forms/signup_form.py
@@ -1,0 +1,22 @@
+from django import forms
+from django.views.generic.edit import FormView
+from django.contrib.auth.models import User
+
+
+class SignUpForm(forms.Form):
+    username = forms.CharField()
+    password = forms.CharField(widget=forms.PasswordInput())
+
+    def create_user(self):
+        data = self.cleaned_data
+        User.objects.create_user(username=data['username'], password=data['password'])
+
+
+class SignUpView(FormView):
+    template_name = 'auth/signup.html'
+    form_class = SignUpForm
+    success_url = '/'
+
+    def form_valid(self, form: SignUpForm):
+        form.create_user()
+        return super().form_valid()

--- a/socialdistribution/settings.py
+++ b/socialdistribution/settings.py
@@ -54,7 +54,7 @@ ROOT_URLCONF = 'socialdistribution.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [str(BASE_DIR.joinpath('templates'))],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -116,6 +116,10 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/4.0/howto/static-files/
 
 STATIC_URL = 'static/'
+
+STATICFILES_DIRS = [
+    'static'
+]
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.0/ref/settings/#default-auto-field

--- a/socialdistribution/urls.py
+++ b/socialdistribution/urls.py
@@ -17,8 +17,10 @@ from django.contrib import admin
 from django.urls import path
 from django.contrib.auth.views import LoginView
 
+from . import views
 
 urlpatterns = [
+    path('', views.root),
     path('admin/', admin.site.urls),
     path('login', LoginView.as_view(template_name='auth/login.html'), name='login'),
 ]

--- a/socialdistribution/urls.py
+++ b/socialdistribution/urls.py
@@ -18,9 +18,12 @@ from django.urls import path
 from django.contrib.auth.views import LoginView
 
 from . import views
+from .forms.signup_form import SignUpView
+
 
 urlpatterns = [
     path('', views.root),
     path('admin/', admin.site.urls),
+    path('signup', SignUpView.as_view(), name='signup'),
     path('login', LoginView.as_view(template_name='auth/login.html'), name='login'),
 ]

--- a/socialdistribution/urls.py
+++ b/socialdistribution/urls.py
@@ -15,7 +15,10 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
+from django.contrib.auth.views import LoginView
+
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('login', LoginView.as_view(template_name='auth/login.html'), name='login'),
 ]

--- a/socialdistribution/views.py
+++ b/socialdistribution/views.py
@@ -1,0 +1,9 @@
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import redirect
+
+
+def root(request: HttpRequest) -> HttpResponse:
+    if request.user.is_anonymous:
+        return redirect('login')
+    # TODO: redirect to user's stream page
+    return HttpResponse("Main app")

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,4 @@
+html,
+body {
+  margin: 0;
+}

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %} {% block content %} {% if form.errors %}
+<div class="alert">
+  <p>Username and password did not match</p>
+</div>
+{% endif %}
+
+<h1>Login</h1>
+<form method="post" action="{% url 'login' %}">
+  {% csrf_token %}
+
+  <table>
+    {{ form.as_table }}
+  </table>
+
+  <input type="submit" value="Login" />
+  <input type="hidden" name="next" value="{{ next }}" />
+</form>
+
+<p>Don't have an account? <a href="{%url 'signup' %}">Sign up</a></p>
+
+{% endblock %}

--- a/templates/auth/signup.html
+++ b/templates/auth/signup.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %} {% block content %}
+
+<h1>Sign up</h1>
+<form method="post" action="{% url 'signup' %}">
+  {% csrf_token %}
+
+  <table>
+    {{ form.as_table }}
+  </table>
+
+  <input type="submit" value="Sign up" />
+</form>
+
+<p>Already have an account? <a href="{%url 'login' %}">Log in</a></p>
+
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    {% load static %}
+    <link rel="stylesheet" href="{% static 'styles.css' %}" />
+    <title>socialDISTRIBUTION</title>
+  </head>
+
+  <body>
+    <div id="content">{% block content %}{% endblock %}</div>
+  </body>
+</html>

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,21 @@
+from django.test import TestCase, Client
+
+
+class AuthTests(TestCase):
+    def setUp(self) -> None:
+        self.client = Client()
+
+    def test_login_page(self):
+        res = self.client.get('/login')
+        self.assertEqual(res.status_code, 200)
+        self.assertTemplateUsed('auth/login.html')
+
+    def test_signup_page(self):
+        res = self.client.get('/signup')
+        self.assertEqual(res.status_code, 200)
+        self.assertTemplateUsed('auth/signup.html')
+
+    def test_login_redirect(self):
+        res = self.client.get('/')
+        self.assertEqual(res.status_code, 302)
+        self.assertEqual(res.get('Location'), '/login')


### PR DESCRIPTION
## Overview
* Add login and sign up pages
  * Use `django.contrib.auth` for most of the work

## TODOs
* Consider using [UserCreationForm](https://docs.djangoproject.com/en/4.0/topics/auth/default/#django.contrib.auth.forms.UserCreationForm) in place of [SignUpForm]
* Extend User model such that sign ups require server admin approval before the user is regarded as active
* Style pages

## Notes
* Depends on #1  

## Screenshots
| | |
| --- | --- |
| <img width="346" alt="image" src="https://user-images.githubusercontent.com/43416725/153690759-6d36281a-b64a-431f-9f91-7c928912fd43.png"> | <img width="270" alt="image" src="https://user-images.githubusercontent.com/43416725/153690767-bf8e038f-78f3-4680-bb0b-181d48942fa1.png">
