### PR TITLE
Add Public Stream Posts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 # Dev specific
 venv/
 **/__pycache__
+.vscode

--- a/posts/templates/posts/partials/_stream_post.html
+++ b/posts/templates/posts/partials/_stream_post.html
@@ -1,0 +1,21 @@
+ 
+<li>
+	<table>
+		<tbody>
+			<tr>
+				<h3> {{ post.title }} </h3>
+			</tr>
+			<tr>
+				<p>{{ post.description }}</p>
+			</tr>
+			<tr>
+				{% if post.content_type == 'text/plain' %}
+					<p>{{ post.content }}</p>
+				{% endif %}
+			</tr>
+			<tr>
+				<p>{{ post.date_published }}</p>
+			</tr>			
+		</tbody>
+	</table>
+</li>

--- a/socialdistribution/urls.py
+++ b/socialdistribution/urls.py
@@ -21,6 +21,7 @@ from . import views
 
 urlpatterns = [
     path('', views.root),
+    path('stream/', views.StreamView.as_view()),
     path('posts/', include('posts.urls')),
     path('admin/', admin.site.urls),
     path('accounts/', include('auth_provider.urls')),

--- a/socialdistribution/views.py
+++ b/socialdistribution/views.py
@@ -1,9 +1,22 @@
 from django.urls import reverse_lazy
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
+from django.views.generic.list import ListView
+
+from posts.models import Post
 
 
 def root(request: HttpRequest) -> HttpResponse:
     if request.user.is_anonymous:
         return redirect(reverse_lazy('auth_provider:login'))
-    return render(request, 'stream.html')
+    return redirect('/stream')
+
+class StreamView(ListView):
+    model = Post
+    paginate_by = 100
+    template_name = 'stream.html'
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['object_list'] = Post.objects.filter(visibility=Post.Visibility.PUBLIC, unlisted=False).order_by('-date_published')
+        return context

--- a/socialdistribution/views.py
+++ b/socialdistribution/views.py
@@ -18,5 +18,7 @@ class StreamView(ListView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['object_list'] = Post.objects.filter(visibility=Post.Visibility.PUBLIC, unlisted=False).order_by('-date_published')
+        context['object_list'] = Post.objects.filter(
+            visibility=Post.Visibility.PUBLIC, 
+            unlisted=False).order_by('-date_published')
         return context

--- a/socialdistribution/views.py
+++ b/socialdistribution/views.py
@@ -11,6 +11,7 @@ def root(request: HttpRequest) -> HttpResponse:
         return redirect(reverse_lazy('auth_provider:login'))
     return redirect('/stream')
 
+
 class StreamView(ListView):
     model = Post
     paginate_by = 100
@@ -19,6 +20,6 @@ class StreamView(ListView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['object_list'] = Post.objects.filter(
-            visibility=Post.Visibility.PUBLIC, 
+            visibility=Post.Visibility.PUBLIC,
             unlisted=False).order_by('-date_published')
         return context

--- a/templates/stream.html
+++ b/templates/stream.html
@@ -5,21 +5,13 @@
 	<a href="{% url 'posts:new' %}">New post</a>
 
 	<ul>
-	{% for post in object_list %}
-		<li>
-			<h3>{{post.title}}</h3>
-			<p>{{post.description}}</p>
-			{% comment %} {% if post.content_type == Post.ContentType.PLAIN %} {% endcomment %}
-			{% if post.content_type == 'text/plain' %}
-				<p>{{post.content}}</p>
-			{% endif %}
-			<p>{{post.date_published}}</p>
-		</li>
-	{% empty %}
-		<li> No posts yet. </li>
-	{% endfor %}
+		{% for post in object_list %}
+			{% include "posts/partials/_stream_post.html" %}
+		{% empty %}
+			<li> No posts yet. </li>
+		{% endfor %}
 	</ul>
 
 </div>
 
-{% endblock %}
+{% endblock content %}

--- a/templates/stream.html
+++ b/templates/stream.html
@@ -1,8 +1,24 @@
 {% extends "base.html" %} {% block content %}
 
-<h1>socialDISTRIBUTION</h1>\
+<h1>socialDISTRIBUTION</h1>
 <div class="container">
 	<a href="{% url 'posts:new' %}">New post</a>
+
+	<ul>
+	{% for post in object_list %}
+		<li>
+			<h3>{{post.title}}</h3>
+			<p>{{post.description}}</p>
+			{% comment %} {% if post.content_type == Post.ContentType.PLAIN %} {% endcomment %}
+			{% if post.content_type == 'text/plain' %}
+				<p>{{post.content}}</p>
+			{% endif %}
+			<p>{{post.date_published}}</p>
+		</li>
+	{% empty %}
+		<li> No posts yet. </li>
+	{% endfor %}
+	</ul>
 
 </div>
 


### PR DESCRIPTION
### Overview
- Adds a basic 'stream' that shows a (currently unstyled) feed of posts that are PUBLIC and not unlisted
- Posts are displayed in reverse-chronological order (new at the top) 
- Creates a partial template for stream posts that can be reused

![image](https://user-images.githubusercontent.com/54957139/156433757-ae16d37b-0499-4d8b-8e45-cbaed59d1403.png)

Closes #40 