### PR TITLE
Display remote posts in detailed view

### DIFF
--- a/posts/templates/posts/remote_post_detail.html
+++ b/posts/templates/posts/remote_post_detail.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %} {% block content %}
+<div class="card">
+  <h2>{{ object.title }}</h2>
+  <h3 class="subtitle">{{ object.author.get_full_name }}</h3>
+  {% if object.content_type == 'text' %} <!-- TODO: Update this when our friends have updated their contentType field -->
+  <p>{{ object.content }}</p>
+  {% elif object.content_type == 'image/png;base64' or object.content_type == 'image/jpeg;base64' %}
+  {% if object.img_content %}
+  <img src="{{ object.img_content.url }}" height="auto" width="100%" alt="alt" />
+  {% else %}
+  <img src="{{ object.content }}" height="auto" width="100%" alt="alt" />
+  {% endif %}
+  {% endif %}
+
+  <p>{{ object.date_published }}</p>
+
+  <section id="categories">
+    <ol class="horizontal no-indent">
+      {% for category in object.categories.all %}
+      <li class="pill">{{ category.category }}</li>
+      {% endfor %}
+    </ol>
+  </section>
+
+  <!-- TODO: Re-add comments section -->
+  <!-- TODO: Re-add likes section -->
+</div>
+{% endblock content %}

--- a/posts/tests/test_views.py
+++ b/posts/tests/test_views.py
@@ -157,6 +157,15 @@ class PostDetailViewTests(TestCase):
         self.assertNotContains(res, 'Like')
 
 
+class PostDetailViewTests(TestCase):
+    def setUp(self) -> None:
+        pass
+
+    def test_remote_detail_view_page(self):
+        # TODO: Add tests
+        pass
+
+
 class PostDeleteViewTests(TestCase):
     def setUp(self) -> None:
         self.client = Client()

--- a/posts/urls.py
+++ b/posts/urls.py
@@ -3,7 +3,7 @@ from django.urls import path
 
 app_name = 'posts'
 urlpatterns = [
-    path('remote/<path:url>', views.RemotePostDetailView.as_view(), name='edit'),
+    path('remote/<path:url>', views.RemotePostDetailView.as_view(), name='remote-detail'),
     path('<int:pk>/edit', views.EditPostView.as_view(), name='edit'),
     path('<int:pk>/delete', views.DeletePostView.as_view(), name='delete'),
     path('<int:pk>/comments/new', views.CreateCommentView.as_view(), name='new-comment'),

--- a/posts/urls.py
+++ b/posts/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 
 app_name = 'posts'
 urlpatterns = [
+    path('remote/<path:url>', views.RemotePostDetailView.as_view(), name='edit'),
     path('<int:pk>/edit', views.EditPostView.as_view(), name='edit'),
     path('<int:pk>/delete', views.DeletePostView.as_view(), name='delete'),
     path('<int:pk>/comments/new', views.CreateCommentView.as_view(), name='new-comment'),

--- a/servers/views/generic/detailed_view.py
+++ b/servers/views/generic/detailed_view.py
@@ -9,11 +9,12 @@ from servers.models import Server
 
 from posts.models import Post
 
+
 class ServerDetailView(DetailView):
     # Override this method to map their object to ours
     to_internal: Callable[[Response], Any] = None
 
-    def get_object(self, queryset: Optional[models.query.QuerySet]=None) -> Post:
+    def get_object(self, queryset: Optional[models.query.QuerySet] = None) -> Post:
         servers = Server.objects.all()
         url = self.kwargs['url']
         for server in servers:
@@ -25,5 +26,5 @@ class ServerDetailView(DetailView):
                 self.to_internal(resp)
             except Exception as err:
                 print(f'Failed to internalize {url}, err={err}', file=stderr)
-        
+
         raise Http404

--- a/servers/views/generic/detailed_view.py
+++ b/servers/views/generic/detailed_view.py
@@ -1,0 +1,29 @@
+from sys import stderr
+from typing import Any, Callable, Optional
+from django.views.generic import DetailView
+from django.http import Http404
+from django.db import models
+from requests import get, Response
+
+from servers.models import Server
+
+from posts.models import Post
+
+class ServerDetailView(DetailView):
+    # Override this method to map their object to ours
+    to_internal: Callable[[Response], Any] = None
+
+    def get_object(self, queryset: Optional[models.query.QuerySet]=None) -> Post:
+        servers = Server.objects.all()
+        url = self.kwargs['url']
+        for server in servers:
+            if not url.startswith(server.service_address):
+                continue
+            # Trim prefix
+            resp = server.get(url[len(server.service_address):])
+            try:
+                self.to_internal(resp)
+            except Exception as err:
+                print(f'Failed to internalize {url}, err={err}', file=stderr)
+        
+        raise Http404

--- a/servers/views/generic/detailed_view.py
+++ b/servers/views/generic/detailed_view.py
@@ -23,8 +23,8 @@ class ServerDetailView(DetailView):
             # Trim prefix
             resp = server.get(url[len(server.service_address):])
             try:
-                self.to_internal(resp)
+                return self.to_internal(resp)
             except Exception as err:
-                print(f'Failed to internalize {url}, err={err}', file=stderr)
+                print(f'Failed to internalize {url}, err: {err.with_traceback(None)}', file=stderr)
 
         raise Http404

--- a/socialdistribution/tests.py
+++ b/socialdistribution/tests.py
@@ -74,6 +74,7 @@ class StreamViewTests(TestCase):
         ]'''
         mock_json_response = json.loads(mock_raw_json_response)
         mock_response = Response()
+        mock_response.url = 'http://localhost:5555/api/v2/authors/1/posts'
         mock_response.json = MagicMock(return_value=mock_json_response)
 
         mock_server = Server(

--- a/socialdistribution/views.py
+++ b/socialdistribution/views.py
@@ -5,6 +5,7 @@ from django.shortcuts import redirect
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db.models import QuerySet
 from requests import Response
+import urllib.parse
 
 from posts.models import Post
 from servers.views.generic.list_view import ServerListView
@@ -43,13 +44,18 @@ class StreamView(LoginRequiredMixin, ServerListView):
         json_response = response.json()
 
         def to_internal(representation: dict[str, Any]):
+            request_url = response.url
+            if not request_url.endswith('/'):
+                request_url += '/'
+            post_url = urllib.parse.urljoin(request_url, representation['id']) # TODO: Update this to source or origin
+            absolute_url = reverse('posts:remote-detail', kwargs={'url': post_url})
             return {
                 'title': representation['title'],
                 'description': representation['description'],
                 'content_type': representation['contentType'],
                 'content': representation['content'],
                 'date_published': representation['published'],
-                'get_absolute_url': representation['source'],  # TODO: Verify whether this is the correct field
+                'get_absolute_url': absolute_url,
             }
 
         # TODO: Add ['items'] once our groupmates are ready (have the results nested)

--- a/socialdistribution/views.py
+++ b/socialdistribution/views.py
@@ -47,7 +47,7 @@ class StreamView(LoginRequiredMixin, ServerListView):
             request_url = response.url
             if not request_url.endswith('/'):
                 request_url += '/'
-            post_url = urllib.parse.urljoin(request_url, representation['id']) # TODO: Update this to source or origin
+            post_url = urllib.parse.urljoin(request_url, representation['id'])  # TODO: Update this to source or origin
             absolute_url = reverse('posts:remote-detail', kwargs={'url': post_url})
             return {
                 'title': representation['title'],


### PR DESCRIPTION
### Overview
* Add a new `/posts/remote/<path>` endpoint
  * I don't think we can extend Post's existing `DetailView` to display the remote one because of the pk url constraint
* Caveats
  * No comments section
  * No likes
  * No images (mostly because we don't have a sample post with an image)
* Tests are currently broken (MagicMock isn't behaving as what I'd expect it to) so I'd like to add tests in a different PR while fixing the existing ones
  * Meanwhile you can test by adding a valid server endpoint (one of group 12's or 11's, then clicking on their post on your stream)

### Notes
* Apparently `/`'s in url is considered safe so we don't need to escape it using `urllib.parse.quote` (if we do `reverse` will double quote it for us which is a problem)

```
https://cmput404-project-t12.herokuapp.com/service/authors/32d6cbd8-3a30-4a78-a4c4-c1d99e208f6a/posts/dc08e5e2-038b-479b-b509-2a6d7b9298ad

# uri encoded using node
https%3A%2F%2Fcmput404-project-t12.herokuapp.com%2Fservice%2Fauthors%2F32d6cbd8-3a30-4a78-a4c4-c1d99e208f6a%2Fposts%2Fdc08e5e2-038b-479b-b509-2a6d7b9298ad

# what reverse('posts:remote-detail', kwargs={'url' : escaped}) produces
https%253A%252F%252Fcmput404-project-t12.herokuapp.com%252Fservice%252Fauthors%252F32d6cbd8-3a30-4a78-a4c4-c1d99e208f6a%252Fposts%252Fdc08e5e2-038b-479b-b509-2a6d7b9298ad
```