### PR TITLE
Optimize API calls

### DIFF
--- a/api/tests/constants.py
+++ b/api/tests/constants.py
@@ -43,3 +43,38 @@ POST_IMG_DATA = {
     'visibility': Post.Visibility.PUBLIC,
     'unlisted': False,
 }
+
+# TODO: Update this when our groupmates have updated their interface
+SAMPLE_REMOTE_POST = '''
+[{
+    "title": "anonymouspost",
+    "id": "1",
+    "source": "https://cmput404-project-t12.herokuapp.com/posts/1",
+    "origin": "https://cmput404-project-t12.herokuapp.com/posts/1",
+    "description": "anonymouspost",
+    "contentType": "text",
+    "content": "anonymouspost",
+    "image": null,
+    "image_src": "",
+    "author": "3",
+    "categories": "undefined",
+    "like_count": 3,
+    "comments": "",
+    "published": "2022-03-21T22:44:16.876579Z",
+    "visibility": "PUBLIC",
+    "unlisted": false
+}]'''
+
+SAMPLE_AUTHORS = '''
+{
+    "type": "authors",
+    "items": [
+        {
+        "id": "32d6cbd8-3a30-4a78-a4c4-c1d99e208f6a",
+        "host": "https://cmput404-project-t12.herokuapp.com/",
+        "displayName": "zhijian1",
+        "github": "https://github.com/Zhijian-Mei",
+        "profileImage": "/mysite/img/default_mSfB41u.jpeg"
+        }
+    ]
+}'''

--- a/servers/views/generic/list_view.py
+++ b/servers/views/generic/list_view.py
@@ -23,8 +23,8 @@ class ServerListView(ListView):
         context = super().get_context_data(**kwargs)
         context['object_list'] = [obj for obj in context['object_list']]
 
-        for endpoint in self.get_endpoints():
-            for server in Server.objects.all():
+        for (server, endpoints) in self.get_server_to_endpoints_mapping():
+            for endpoint in endpoints:
                 try:
                     resp = server.get(endpoint)
                     context['object_list'] += self.serialize(resp)
@@ -33,10 +33,9 @@ class ServerListView(ListView):
         return context
 
     # Override this method if there are multiple endpoints to fetch
-    def get_endpoints(self) -> list[str]:
+    def get_server_to_endpoints_mapping(self) -> list[tuple[Server, list[str]]]:
         if self.endpoint is None:
             raise ImproperlyConfigured(
                 "No endpoint configured for multi resource list"
             )
-
-        return [self.endpoint]
+        return [(server, [self.endpoint]) for server in Server.objects.all()]

--- a/socialdistribution/tests.py
+++ b/socialdistribution/tests.py
@@ -1,9 +1,10 @@
 import json
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from requests import Response
 from django.test import TestCase, Client
 from django.urls import reverse_lazy
 from django.contrib.auth import get_user_model
+from api.tests.constants import SAMPLE_REMOTE_POST
 from api.tests.test_api import TEST_PASSWORD, TEST_USERNAME
 
 from posts.models import Post
@@ -51,28 +52,7 @@ class StreamViewTests(TestCase):
         self.assertContains(res, POST_DATA['title'], count=self.num_posts)
 
     def test_displays_remote_posts(self):
-        # TODO: Update this when our groupmates have updated their interface
-        mock_raw_json_response = '''[
-            {
-                "title": "anonymouspost",
-                "id": "1",
-                "source": "https://cmput404-project-t12.herokuapp.com/posts/1",
-                "origin": "https://cmput404-project-t12.herokuapp.com/posts/1",
-                "description": "anonymouspost",
-                "contentType": "text",
-                "content": "anonymouspost",
-                "image": null,
-                "image_src": "",
-                "author": "3",
-                "categories": "undefined",
-                "like_count": 3,
-                "comments": "",
-                "published": "2022-03-21T22:44:16.876579Z",
-                "visibility": "PUBLIC",
-                "unlisted": false
-            }
-        ]'''
-        mock_json_response = json.loads(mock_raw_json_response)
+        mock_json_response = json.loads(SAMPLE_REMOTE_POST)
         mock_response = Response()
         mock_response.url = 'http://localhost:5555/api/v2/authors/1/posts'
         mock_response.json = MagicMock(return_value=mock_json_response)
@@ -84,14 +64,14 @@ class StreamViewTests(TestCase):
         )
         mock_server.get = MagicMock(return_value=mock_response)
 
-        mock_post_endpoints = [f'{mock_server.service_address}/authors/1/posts']
-        StreamView.get_endpoints = MagicMock(return_value=mock_post_endpoints)
+        with patch.object(StreamView, 'get_server_to_endpoints_mapping') as mock_get_server_to_endpoints_mapping:
+            mock_server_to_endpoints_mapping = [(mock_server, ['/authors/1/posts'])]
+            mock_get_server_to_endpoints_mapping.return_value =mock_server_to_endpoints_mapping
+            with patch('servers.models.Server.objects') as MockServerObjects:
+                MockServerObjects.all.return_value = [mock_server]
 
-        mock_servers = [mock_server]
-        Server.objects.all = MagicMock(return_value=mock_servers)
+                self.client.login(username=TEST_USERNAME, password=TEST_PASSWORD)
+                res = self.client.get(reverse_lazy('stream'))
+                self.assertEqual(res.status_code, 200)
 
-        self.client.login(username=TEST_USERNAME, password=TEST_PASSWORD)
-        res = self.client.get(reverse_lazy('stream'))
-        self.assertEqual(res.status_code, 200)
-
-        self.assertContains(res, mock_json_response[0]['title'])
+                self.assertContains(res, mock_json_response[0]['title'])

--- a/socialdistribution/tests.py
+++ b/socialdistribution/tests.py
@@ -66,7 +66,7 @@ class StreamViewTests(TestCase):
 
         with patch.object(StreamView, 'get_server_to_endpoints_mapping') as mock_get_server_to_endpoints_mapping:
             mock_server_to_endpoints_mapping = [(mock_server, ['/authors/1/posts'])]
-            mock_get_server_to_endpoints_mapping.return_value =mock_server_to_endpoints_mapping
+            mock_get_server_to_endpoints_mapping.return_value = mock_server_to_endpoints_mapping
             with patch('servers.models.Server.objects') as MockServerObjects:
                 MockServerObjects.all.return_value = [mock_server]
 

--- a/socialdistribution/views.py
+++ b/socialdistribution/views.py
@@ -64,5 +64,9 @@ class StreamView(LoginRequiredMixin, ServerListView):
                 'get_absolute_url': absolute_url,
             }
 
-        # TODO: Add ['items'] once our groupmates are ready (have the results nested)
-        return [to_internal(post) for post in json_response]
+        # TODO: Remove this if group 13 implements placing posts under items
+        if isinstance(json_response, list):
+            return [to_internal(post) for post in json_response]
+        
+        return [to_internal(post) for post in json_response['items']]
+        

--- a/socialdistribution/views.py
+++ b/socialdistribution/views.py
@@ -45,7 +45,6 @@ class StreamView(LoginRequiredMixin, ServerListView):
             server_endpoints_tuples.append((server, endpoints))
         return server_endpoints_tuples
 
-
     def serialize(self, response: Response) -> list:
         json_response = response.json()
 
@@ -67,6 +66,5 @@ class StreamView(LoginRequiredMixin, ServerListView):
         # TODO: Remove this if group 13 implements placing posts under items
         if isinstance(json_response, list):
             return [to_internal(post) for post in json_response]
-        
+
         return [to_internal(post) for post in json_response['items']]
-        

--- a/socialdistribution/views.py
+++ b/socialdistribution/views.py
@@ -28,17 +28,20 @@ class StreamView(LoginRequiredMixin, ServerListView):
             visibility=Post.Visibility.PUBLIC,
             unlisted=False).order_by('-date_published')
 
-    def get_endpoints(self) -> list[str]:
-        post_endpoints = []
+    def get_server_to_endpoints_mapping(self) -> list[tuple[Server, list[str]]]:
+        server_endpoints_tuples = []
         for server in Server.objects.all():
             resp = server.get('/authors/')
             authors = resp.json()['items']
+            endpoints = []
             for author in authors:
                 author_id = author['id']
                 # TODO: Update this to author_url once our groupmates are ready (have the URL field)
                 authors_posts = f'/authors/{author_id}/posts'
-                post_endpoints.append(authors_posts)
-        return post_endpoints
+                endpoints.append(authors_posts)
+            server_endpoints_tuples.append((server, endpoints))
+        return server_endpoints_tuples
+
 
     def serialize(self, response: Response) -> list:
         json_response = response.json()

--- a/socialdistribution/views.py
+++ b/socialdistribution/views.py
@@ -32,11 +32,14 @@ class StreamView(LoginRequiredMixin, ServerListView):
         server_endpoints_tuples = []
         for server in Server.objects.all():
             resp = server.get('/authors/')
+            authors_endpoint = server.service_address + '/authors/'
             authors = resp.json()['items']
             endpoints = []
             for author in authors:
-                author_id = author['id']
                 # TODO: Update this to author_url once our groupmates are ready (have the URL field)
+                author_id = author['id']
+                if author_id.startswith(authors_endpoint):
+                    author_id = author_id[len(authors_endpoint):]
                 authors_posts = f'/authors/{author_id}/posts'
                 endpoints.append(authors_posts)
             server_endpoints_tuples.append((server, endpoints))


### PR DESCRIPTION
### Overview
* Previous implementation brute forced urls against every server we have (this would result with O(m*n) requests where m is the number of servers and n is the total number of endpoints we have to fetch from)
* Now we only make n fetches because we intelligently map which server should fetch which endpoint

| previous | now | 
| --- | --- |
| <img width="473" alt="image" src="https://user-images.githubusercontent.com/43416725/160038032-c586bdd9-a61a-421f-b97a-85faed5ca208.png"> | <img width="464" alt="image" src="https://user-images.githubusercontent.com/43416725/160038044-5f3e6307-238c-40f3-955f-87e01812a94a.png">

### Minor improvements
* Fix magic mock tests (previously magicmocks would spill over across test suites)