### PR TITLE
Add Support for Team 9's Routing

### DIFF
--- a/follow/views.py
+++ b/follow/views.py
@@ -77,7 +77,7 @@ def unfollow_request(request, from_username):
 class UsersView(LoginRequiredMixin, ServerListView):
     model = USER_MODEL
     template_name = 'follow/user_list.html'
-    endpoint = '/authors/'
+    endpoint = '/authors'
 
     def serialize(self, response: Response):
         jsonResponse = response.json()

--- a/socialdistribution/views.py
+++ b/socialdistribution/views.py
@@ -31,11 +31,7 @@ class StreamView(LoginRequiredMixin, ServerListView):
     def get_server_to_endpoints_mapping(self) -> list[tuple[Server, list[str]]]:
         server_endpoints_tuples = []
         for server in Server.objects.all():
-            resp = server.get('/authors/')
-            if resp.status_code != 200:
-                resp = server.get('/authors')
-                if resp.status_code != 200:
-                    continue
+            resp = server.get('/authors')
             authors_endpoint = server.service_address + '/authors/'
             authors = resp.json()['items']
             endpoints = []

--- a/socialdistribution/views.py
+++ b/socialdistribution/views.py
@@ -32,6 +32,10 @@ class StreamView(LoginRequiredMixin, ServerListView):
         server_endpoints_tuples = []
         for server in Server.objects.all():
             resp = server.get('/authors/')
+            if resp.status_code != 200:
+                resp = server.get('/authors')
+                if resp.status_code != 200:
+                    continue
             authors_endpoint = server.service_address + '/authors/'
             authors = resp.json()['items']
             endpoints = []


### PR DESCRIPTION
### Overview
Team 9's routes only work _without_ the trailing slash (`/`) for **all** of their endpoints.
- Add fail-safe when getting stream posts to check for `/authors/` and then if it fails, check `/authors`
- Remove the trailing slash when querying their `/authors` endpoint in the users tab

### Media
#### Team 9's remote posts
![image](https://user-images.githubusercontent.com/54957139/160044978-9e2dbeec-09fd-47d1-8fbe-054482539648.png)

#### Team 9's user
![image](https://user-images.githubusercontent.com/54957139/160045295-093b5c5c-a5ac-4461-8fba-a51e7fe9fdb3.png)

### Notes
I also think that Team 13 is currently having issues, or cleared their post database, as none of their posts are coming through locally or on prod. 