### PR TITLE
Display author names in remote posts

### DIFF
--- a/api/tests/constants.py
+++ b/api/tests/constants.py
@@ -86,7 +86,7 @@ SAMPLE_REMOTE_POST = '''
   "unlisted": false
 }]'''
 
-SAMPLE_AUTHORS = '''
+SAMPLE_REMOTE_AUTHOR = '''
 {
     "type": "authors",
     "items": [

--- a/api/tests/constants.py
+++ b/api/tests/constants.py
@@ -47,22 +47,43 @@ POST_IMG_DATA = {
 # TODO: Update this when our groupmates have updated their interface
 SAMPLE_REMOTE_POST = '''
 [{
-    "title": "anonymouspost",
-    "id": "1",
-    "source": "https://cmput404-project-t12.herokuapp.com/posts/1",
-    "origin": "https://cmput404-project-t12.herokuapp.com/posts/1",
-    "description": "anonymouspost",
-    "contentType": "text",
-    "content": "anonymouspost",
-    "image": null,
-    "image_src": "",
-    "author": "3",
-    "categories": "undefined",
-    "like_count": 3,
-    "comments": "",
-    "published": "2022-03-21T22:44:16.876579Z",
-    "visibility": "PUBLIC",
-    "unlisted": false
+  "id": "https://psdt11.herokuapp.com/authors/28b32de4-e5cc-4840-a6ea-8c05dca9dae6/posts/a8cd37e4-be1c-4f86-99cb-b20b1440606f",
+  "type": "post",
+  "author": {
+    "type": "author",
+    "id": "https://psdt11.herokuapp.com/authors/28b32de4-e5cc-4840-a6ea-8c05dca9dae6",
+    "url": "https://psdt11.herokuapp.com/authors/28b32de4-e5cc-4840-a6ea-8c05dca9dae6",
+    "host": "https://psdt11.herokuapp.com/",
+    "display_name": "Jarrett Knauer",
+    "github": "https://github.com/jlknauer"
+  },
+  "comment_src": [
+    {
+      "type": "comment",
+      "author": {
+        "type": "author",
+        "id": "https://psdt11.herokuapp.com/authors/28b32de4-e5cc-4840-a6ea-8c05dca9dae6",
+        "url": "https://psdt11.herokuapp.com/authors/28b32de4-e5cc-4840-a6ea-8c05dca9dae6",
+        "host": "https://psdt11.herokuapp.com/",
+        "display_name": "Jarrett Knauer",
+        "github": "https://github.com/jlknauer"
+      },
+      "comment": "First comment on the post!",
+      "published": "2022-03-23T00:01:32Z",
+      "id": "https://psdt11.herokuapp.com/authors/28b32de4-e5cc-4840-a6ea-8c05dca9dae6/posts/a8cd37e4-be1c-4f86-99cb-b20b1440606f/comments/e1b71a73-f302-4999-916a-2f5d57c4c626"
+    }
+  ],
+  "title": "Hello from Team 11",
+  "source": "",
+  "origin": "",
+  "description": "This is a test post",
+  "content_type": "text/plain",
+  "content": "Web dev sucks",
+  "count": 0,
+  "comments": "https://psdt11.herokuapp.com/authors/28b32de4-e5cc-4840-a6ea-8c05dca9dae6/posts/a8cd37e4-be1c-4f86-99cb-b20b1440606f/comments",
+  "published": "2022-03-23T00:01:32Z",
+  "visibility": "PUBLIC",
+  "unlisted": false
 }]'''
 
 SAMPLE_AUTHORS = '''

--- a/api/tests/constants.py
+++ b/api/tests/constants.py
@@ -45,7 +45,7 @@ POST_IMG_DATA = {
 }
 
 # TODO: Update this when our groupmates have updated their interface
-SAMPLE_REMOTE_POST = '''
+SAMPLE_REMOTE_POSTS = '''
 [{
   "id": "https://psdt11.herokuapp.com/authors/28b32de4-e5cc-4840-a6ea-8c05dca9dae6/posts/a8cd37e4-be1c-4f86-99cb-b20b1440606f",
   "type": "post",
@@ -85,6 +85,48 @@ SAMPLE_REMOTE_POST = '''
   "visibility": "PUBLIC",
   "unlisted": false
 }]'''
+
+SAMPLE_REMOTE_POST = '''
+{
+  "id": "https://psdt11.herokuapp.com/authors/28b32de4-e5cc-4840-a6ea-8c05dca9dae6/posts/a8cd37e4-be1c-4f86-99cb-b20b1440606f",
+  "type": "post",
+  "author": {
+    "type": "author",
+    "id": "https://psdt11.herokuapp.com/authors/28b32de4-e5cc-4840-a6ea-8c05dca9dae6",
+    "url": "https://psdt11.herokuapp.com/authors/28b32de4-e5cc-4840-a6ea-8c05dca9dae6",
+    "host": "https://psdt11.herokuapp.com/",
+    "display_name": "Jarrett Knauer",
+    "github": "https://github.com/jlknauer"
+  },
+  "comment_src": [
+    {
+      "type": "comment",
+      "author": {
+        "type": "author",
+        "id": "https://psdt11.herokuapp.com/authors/28b32de4-e5cc-4840-a6ea-8c05dca9dae6",
+        "url": "https://psdt11.herokuapp.com/authors/28b32de4-e5cc-4840-a6ea-8c05dca9dae6",
+        "host": "https://psdt11.herokuapp.com/",
+        "display_name": "Jarrett Knauer",
+        "github": "https://github.com/jlknauer"
+      },
+      "comment": "First comment on the post!",
+      "published": "2022-03-23T00:01:32Z",
+      "id": "https://psdt11.herokuapp.com/authors/28b32de4-e5cc-4840-a6ea-8c05dca9dae6/posts/a8cd37e4-be1c-4f86-99cb-b20b1440606f/comments/e1b71a73-f302-4999-916a-2f5d57c4c626"
+    }
+  ],
+  "title": "Hello from Team 11",
+  "source": "",
+  "origin": "",
+  "description": "This is a test post",
+  "content_type": "text/plain",
+  "content": "Web dev sucks",
+  "count": 0,
+  "comments": "https://psdt11.herokuapp.com/authors/28b32de4-e5cc-4840-a6ea-8c05dca9dae6/posts/a8cd37e4-be1c-4f86-99cb-b20b1440606f/comments",
+  "published": "2022-03-23T00:01:32Z",
+  "visibility": "PUBLIC",
+  "unlisted": false
+}
+'''
 
 SAMPLE_REMOTE_AUTHOR = '''
 {

--- a/follow/tests.py
+++ b/follow/tests.py
@@ -4,7 +4,7 @@ from django.contrib.auth import get_user_model
 from django.urls import reverse
 from unittest.mock import MagicMock, patch
 from requests import Response
-from api.tests.constants import SAMPLE_AUTHORS
+from api.tests.constants import SAMPLE_REMOTE_AUTHOR
 
 from servers.models import Server
 from follow.admin import AddFriendAction
@@ -89,7 +89,7 @@ class UsersViewTests(TestCase):
         self.assertNotContains(res, self.api_user.username)
 
     def test_contains_users_from_other_servers(self):
-        mock_json_response = json.loads(SAMPLE_AUTHORS)
+        mock_json_response = json.loads(SAMPLE_REMOTE_AUTHOR)
         mock_response = Response()
         mock_response.json = MagicMock(return_value=mock_json_response)
 

--- a/follow/views.py
+++ b/follow/views.py
@@ -1,3 +1,4 @@
+from typing import Any
 from django.core.exceptions import ValidationError
 from django.http import HttpResponseNotAllowed
 from django.shortcuts import redirect
@@ -81,13 +82,13 @@ class UsersView(LoginRequiredMixin, ServerListView):
 
     def serialize(self, response: Response):
         jsonResponse = response.json()
-        jsonResponse['items']
 
-        def to_internal(representation):
+        def to_internal(representation: dict[str, Any]):
             return {
-                'get_full_name': representation['displayName'],
-                'username': representation['github'],
+                'get_full_name': representation.get('displayName'),
+                'username': representation.get('github'),
             }
+
         return [to_internal(user) for user in jsonResponse['items']]
 
     def get_queryset(self):

--- a/posts/templates/posts/partials/_stream_post.html
+++ b/posts/templates/posts/partials/_stream_post.html
@@ -1,6 +1,9 @@
 <a href="{{ post.get_absolute_url }}" style="color: inherit">
     <div class="card interactable">
         <h3>{{ post.title }}</h3>
+        <p class="subtitle">
+            {{ post.author.get_full_name }}
+        </p>
         <p>
             {{ post.description }}
         </p>

--- a/posts/templates/posts/remote_post_detail.html
+++ b/posts/templates/posts/remote_post_detail.html
@@ -2,7 +2,7 @@
 <div class="card">
   <h2>{{ object.title }}</h2>
   <h3 class="subtitle">{{ object.author.get_full_name }}</h3>
-  {% if object.content_type == 'text' %} <!-- TODO: Update this when our friends have updated their contentType field -->
+  {% if object.content_type == 'text' or object.content_type == 'text/plain' %} <!-- TODO: Update this when our friends have updated their contentType field -->
   <p>{{ object.content }}</p>
   {% elif object.content_type == 'image/png;base64' or object.content_type == 'image/jpeg;base64' %}
   {% if object.img_content %}

--- a/posts/tests/test_views.py
+++ b/posts/tests/test_views.py
@@ -183,12 +183,15 @@ class PostDetailViewTests(TestCase):
             MockServerObjects.all.return_value = [mock_server]
 
             self.client.login(username=TEST_USERNAME, password=TEST_PASSWORD)
-            res = self.client.get(reverse('posts:remote-detail', kwargs={'url': 'http://localhost:5555/api/v2/authors/1/posts/1/'}))
+            res = self.client.get(
+                reverse(
+                    'posts:remote-detail',
+                    kwargs={
+                        'url': 'http://localhost:5555/api/v2/authors/1/posts/1/'}))
             self.assertEqual(res.status_code, 200)
 
             self.assertContains(res, mock_json_response['title'])
             self.assertContains(res, mock_json_response['author']['display_name'])
-
 
 
 class PostDeleteViewTests(TestCase):

--- a/posts/views.py
+++ b/posts/views.py
@@ -101,6 +101,9 @@ class RemotePostDetailView(LoginRequiredMixin, ServerDetailView):
             'date_published': json_response['published'],
             'visibility': json_response['visibility'],
             'unlisted': json_response['unlisted'],
+            'author': {
+                'get_full_name': json_response['author']['displayName']
+            }
         }
 
 

--- a/posts/views.py
+++ b/posts/views.py
@@ -91,19 +91,18 @@ class RemotePostDetailView(LoginRequiredMixin, ServerDetailView):
     def to_internal(self, response: Response) -> Post:
         json_response = response.json()
         return {
-            'id': json_response['id'],
-            'title': json_response['title'],
-            'description': json_response['description'],
-            'content_type': json_response['contentType'],
-            'content': json_response['content'],
-            'author': json_response['author'],
-            'categories': json_response['categories'],
-            'date_published': json_response['published'],
-            'visibility': json_response['visibility'],
-            'unlisted': json_response['unlisted'],
+            'id': json_response.get('id'),
+            'title': json_response.get('title'),
+            'description': json_response.get('description'),
+            'content_type': json_response.get('contentType') or json_response.get('content_type'),
+            'content': json_response.get('content'),
+            'categories': json_response.get('categories'),
+            'date_published': json_response.get('published'),
+            'visibility': json_response.get('visibility'),
+            'unlisted': json_response.get('unlisted'),
             'author': {
-                'get_full_name': json_response['author']['displayName']
-            }
+                'get_full_name': json_response.get('author').get('displayName') or json_response.get('author').get('display_name')
+            },
         }
 
 

--- a/posts/views.py
+++ b/posts/views.py
@@ -101,8 +101,7 @@ class RemotePostDetailView(LoginRequiredMixin, ServerDetailView):
             'visibility': json_response.get('visibility'),
             'unlisted': json_response.get('unlisted'),
             'author': {
-                'get_full_name': json_response.get('author').get('displayName') or json_response.get('author').get('display_name')
-            },
+                'get_full_name': json_response.get('author').get('displayName') or json_response.get('author').get('display_name')},
         }
 
 

--- a/servers/views/generic/detailed_view.py
+++ b/servers/views/generic/detailed_view.py
@@ -25,6 +25,6 @@ class ServerDetailView(DetailView):
             try:
                 return self.to_internal(resp)
             except Exception as err:
-                print(f'Failed to internalize {url}, err: {server.service_address}', file=stderr)
+                print(f'Failed to internalize {url}, err: {err.with_traceback(None)}', file=stderr)
 
         raise Http404

--- a/servers/views/generic/detailed_view.py
+++ b/servers/views/generic/detailed_view.py
@@ -25,6 +25,6 @@ class ServerDetailView(DetailView):
             try:
                 return self.to_internal(resp)
             except Exception as err:
-                print(f'Failed to internalize {url}, err: {err.with_traceback(None)}', file=stderr)
+                print(f'Failed to internalize {url}, err: {server.service_address}', file=stderr)
 
         raise Http404

--- a/socialdistribution/tests.py
+++ b/socialdistribution/tests.py
@@ -27,6 +27,10 @@ class StreamViewTests(TestCase):
     def setUp(self) -> None:
         self.client = Client()
         self.user = get_user_model().objects.create_user(username=TEST_USERNAME, password=TEST_PASSWORD)
+        self.user.first_name = 'Bob'
+        self.user.last_name = 'Doyle'
+        self.user.save()
+
         self.num_posts = 10
         for i in range(self.num_posts):
             post = Post.objects.create(
@@ -50,6 +54,7 @@ class StreamViewTests(TestCase):
         self.assertEqual(res.status_code, 200)
 
         self.assertContains(res, POST_DATA['title'], count=self.num_posts)
+        self.assertContains(res, self.user.get_full_name())
 
     def test_displays_remote_posts(self):
         mock_json_response = json.loads(SAMPLE_REMOTE_POST)

--- a/socialdistribution/tests.py
+++ b/socialdistribution/tests.py
@@ -4,7 +4,7 @@ from requests import Response
 from django.test import TestCase, Client
 from django.urls import reverse_lazy
 from django.contrib.auth import get_user_model
-from api.tests.constants import SAMPLE_REMOTE_POST
+from api.tests.constants import SAMPLE_REMOTE_POSTS
 from api.tests.test_api import TEST_PASSWORD, TEST_USERNAME
 
 from posts.models import Post
@@ -57,7 +57,7 @@ class StreamViewTests(TestCase):
         self.assertContains(res, self.user.get_full_name())
 
     def test_displays_remote_posts(self):
-        mock_json_response = json.loads(SAMPLE_REMOTE_POST)
+        mock_json_response = json.loads(SAMPLE_REMOTE_POSTS)
         mock_response = Response()
         mock_response.url = 'http://localhost:5555/api/v2/authors/1/posts'
         mock_response.json = MagicMock(return_value=mock_json_response)

--- a/socialdistribution/views.py
+++ b/socialdistribution/views.py
@@ -62,9 +62,7 @@ class StreamView(LoginRequiredMixin, ServerListView):
                 'date_published': representation.get('published'),
                 'get_absolute_url': absolute_url,
                 'author': {
-                    'get_full_name': representation.get('author').get('displayName') or representation.get('author').get('display_name')
-                }
-            }
+                    'get_full_name': representation.get('author').get('displayName') or representation.get('author').get('display_name')}}
 
         # TODO: Remove this if group 13 implements placing posts under items
         if isinstance(json_response, list):

--- a/socialdistribution/views.py
+++ b/socialdistribution/views.py
@@ -55,14 +55,14 @@ class StreamView(LoginRequiredMixin, ServerListView):
             post_url = urllib.parse.urljoin(request_url, representation['id'])  # TODO: Update this to source or origin
             absolute_url = reverse('posts:remote-detail', kwargs={'url': post_url})
             return {
-                'title': representation['title'],
-                'description': representation['description'],
-                'content_type': representation['contentType'],
-                'content': representation['content'],
-                'date_published': representation['published'],
+                'title': representation.get('title'),
+                'description': representation.get('description'),
+                'content_type': representation.get('contentType') or representation.get('content_type'),
+                'content': representation.get('content'),
+                'date_published': representation.get('published'),
                 'get_absolute_url': absolute_url,
                 'author': {
-                    'get_full_name': representation['author']['displayName']
+                    'get_full_name': representation.get('author').get('displayName') or representation.get('author').get('display_name')
                 }
             }
 

--- a/socialdistribution/views.py
+++ b/socialdistribution/views.py
@@ -61,6 +61,9 @@ class StreamView(LoginRequiredMixin, ServerListView):
                 'content': representation['content'],
                 'date_published': representation['published'],
                 'get_absolute_url': absolute_url,
+                'author': {
+                    'get_full_name': representation['author']['displayName']
+                }
             }
 
         # TODO: Remove this if group 13 implements placing posts under items


### PR DESCRIPTION
### Overview
* Display remote author names for demo
* Replace non safe dictionary accesses with gets (will return None if it's not there)

<img width="782" alt="image" src="https://user-images.githubusercontent.com/43416725/160058165-51dd7f83-f30d-4366-a648-8b6ecf2a4934.png">
