### PR TITLE
Display Remote Images in the Remote Detail Post View

### DIFF
--- a/lib/http_helper.py
+++ b/lib/http_helper.py
@@ -1,7 +1,9 @@
 from posts.models import ContentType
 
+
 def is_image_content(content_type: str) -> bool:
     return content_type.startswith('image')
+
 
 def is_b64_image_content(content_type: str) -> bool:
     return content_type == ContentType.PNG or content_type == ContentType.JPG

--- a/lib/http_helper.py
+++ b/lib/http_helper.py
@@ -1,0 +1,7 @@
+from posts.models import ContentType
+
+def is_image_content(content_type: str) -> bool:
+    return content_type.startswith('image')
+
+def is_b64_image_content(content_type: str) -> bool:
+    return content_type == ContentType.PNG or content_type == ContentType.JPG

--- a/posts/templates/posts/remote_post_detail.html
+++ b/posts/templates/posts/remote_post_detail.html
@@ -3,13 +3,9 @@
   <h2>{{ object.title }}</h2>
   <h3 class="subtitle">{{ object.author.get_full_name }}</h3>
   {% if object.content_type == 'text' or object.content_type == 'text/plain' %} <!-- TODO: Update this when our friends have updated their contentType field -->
-  <p>{{ object.content }}</p>
-  {% elif object.content_type == 'image/png;base64' or object.content_type == 'image/jpeg;base64' %}
-  {% if object.img_content %}
-  <img src="{{ object.img_content.url }}" height="auto" width="100%" alt="alt" />
-  {% else %}
-  <img src="{{ object.content }}" height="auto" width="100%" alt="alt" />
-  {% endif %}
+  	<p>{{ object.content }}</p>
+  {% elif object.content_type == 'image/png;base64' or object.content_type == 'image/jpeg;base64' %}  
+  	<img src="data:{{ object.content_type }},{{ object.content }}" height="auto" width="100%" alt="alt" />  
   {% endif %}
 
   <p>{{ object.date_published }}</p>

--- a/posts/views.py
+++ b/posts/views.py
@@ -101,7 +101,7 @@ class RemotePostDetailView(LoginRequiredMixin, ServerDetailView):
                 service_address = origin[0:origin.index('/authors')]
                 service_request = origin[origin.index('/authors'):]
                 server = Server.objects.get(service_address=service_address)
-                img_content = server.get(service_request + '/image').content.decode('utf-8')                
+                img_content = server.get(service_request + '/image').content.decode('utf-8')
             except Exception as e:
                 print('warning: ' + e)
 

--- a/posts/views.py
+++ b/posts/views.py
@@ -10,10 +10,12 @@ from django.views.generic.detail import DetailView
 from django.views.generic.list import ListView
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.urls import reverse_lazy
-from requests import Response
+from requests import Response, get
 
 from posts.models import Post, Category, Comment, Like
+from servers.models import Server
 from servers.views.generic.detailed_view import ServerDetailView
+from lib.http_helper import is_b64_image_content
 
 
 class PostForm(ModelForm):
@@ -90,12 +92,25 @@ class RemotePostDetailView(LoginRequiredMixin, ServerDetailView):
 
     def to_internal(self, response: Response) -> Post:
         json_response = response.json()
+
+        content_type = json_response.get('contentType') or json_response.get('content_type')
+        is_img = is_b64_image_content(content_type)
+        if is_img:
+            try:
+                origin = json_response.get('origin')
+                service_address = origin[0:origin.index('/authors')]
+                service_request = origin[origin.index('/authors'):]
+                server = Server.objects.get(service_address=service_address)
+                img_content = server.get(service_request + '/image').content.decode('utf-8')                
+            except Exception as e:
+                print('warning: ' + e)
+
         return {
             'id': json_response.get('id'),
             'title': json_response.get('title'),
             'description': json_response.get('description'),
-            'content_type': json_response.get('contentType') or json_response.get('content_type'),
-            'content': json_response.get('content'),
+            'content_type': content_type,
+            'content': json_response.get('content') if not is_img or not img_content else img_content,
             'categories': json_response.get('categories'),
             'date_published': json_response.get('published'),
             'visibility': json_response.get('visibility'),

--- a/socialdistribution/views.py
+++ b/socialdistribution/views.py
@@ -52,7 +52,8 @@ class StreamView(LoginRequiredMixin, ServerListView):
             request_url = response.url
             if not request_url.endswith('/'):
                 request_url += '/'
-            post_url = urllib.parse.urljoin(request_url, str(representation['id']))  # TODO: Update this to source or origin
+            # TODO: Update this to source or origin
+            post_url = urllib.parse.urljoin(request_url, str(representation['id']))
             absolute_url = reverse('posts:remote-detail', kwargs={'url': post_url})
             return {
                 'title': representation.get('title'),

--- a/socialdistribution/views.py
+++ b/socialdistribution/views.py
@@ -38,7 +38,7 @@ class StreamView(LoginRequiredMixin, ServerListView):
             for author in authors:
                 # TODO: Update this to author_url once our groupmates are ready (have the URL field)
                 author_id = author['id']
-                if author_id.startswith(authors_endpoint):
+                if isinstance(author_id, str) and author_id.startswith(authors_endpoint):
                     author_id = author_id[len(authors_endpoint):]
                 authors_posts = f'/authors/{author_id}/posts'
                 endpoints.append(authors_posts)
@@ -52,7 +52,7 @@ class StreamView(LoginRequiredMixin, ServerListView):
             request_url = response.url
             if not request_url.endswith('/'):
                 request_url += '/'
-            post_url = urllib.parse.urljoin(request_url, representation['id'])  # TODO: Update this to source or origin
+            post_url = urllib.parse.urljoin(request_url, str(representation['id']))  # TODO: Update this to source or origin
             absolute_url = reverse('posts:remote-detail', kwargs={'url': post_url})
             return {
                 'title': representation.get('title'),


### PR DESCRIPTION
### Overview 
- Fix a few dodgy things that are remote server implementation specific
- Add support to retrieve and display a remote post's image

(tested by adding our Heroku server as a remote server!)
Here is http://localhost:8000/posts/remote/https://socialdistribution-t13.herokuapp.com/api/v1/authors/1/posts/9
![image](https://user-images.githubusercontent.com/54957139/160071781-75025c3e-4eee-4e79-8171-1b7e0c85e216.png)

** Note: This is also a great display of our working image API!!! (it might be broken for linked images.... not sure yet) 