### PR TITLE
Fix Team 12's Posts Not Displaying

### DIFF
--- a/posts/views.py
+++ b/posts/views.py
@@ -116,8 +116,9 @@ class RemotePostDetailView(LoginRequiredMixin, ServerDetailView):
             'visibility': json_response.get('visibility'),
             'unlisted': json_response.get('unlisted'),
             'author': {
-                'get_full_name': json_response.get('author').get('displayName') or json_response.get('author').get('display_name')},
-        }
+                'get_full_name': '' if isinstance(
+                    json_response.get('author'),
+                    str) else json_response.get('author').get('displayName') or json_response.get('author').get('display_name')}}
 
 
 class DeletePostView(LoginRequiredMixin, DeleteView):

--- a/socialdistribution/views.py
+++ b/socialdistribution/views.py
@@ -63,7 +63,9 @@ class StreamView(LoginRequiredMixin, ServerListView):
                 'date_published': representation.get('published'),
                 'get_absolute_url': absolute_url,
                 'author': {
-                    'get_full_name': representation.get('author').get('displayName') or representation.get('author').get('display_name')}}
+                    'get_full_name': '' if isinstance(
+                        representation.get('author'),
+                        str) else representation.get('author').get('displayName') or representation.get('author').get('display_name')}}
 
         # TODO: Remove this if group 13 implements placing posts under items
         if isinstance(json_response, list):


### PR DESCRIPTION
### Overview
Team 12's `/authors` `author` property is a `str` and not an object for some reason. So when we were running `dict.get()` on the deserialized `str` and it was throwing an error. Fixed by checking if the instance is a string, and if so, setting the `full_name` to an empty string. 