### PR TITLE
Allow for Team 12's "text" Content Type in _stream_post.html

### DIFF
--- a/posts/templates/posts/partials/_stream_post.html
+++ b/posts/templates/posts/partials/_stream_post.html
@@ -7,7 +7,8 @@
         <p>
             {{ post.description }}
         </p>
-        {% if post.content_type == 'text/plain' %}
+        <!-- TODO: Update this when our friends have updated their contentType field -->
+        {% if post.content_type == 'text' or post.content_type == 'text/plain' %}
             <p>
                 {{ post.content }}
             </p>


### PR DESCRIPTION
The `content` for Team 12's posts is not being displayed in the stream post view, as it does not have a `text/plain` content type, but rather `text`. Added the same code from the remote detail post. 