### PR TITLE
Cache server requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ media/images
 
 staticfiles/
 *.env
+
+http_cache.sqlite

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,4 @@ tqdm==4.63.0
 urllib3==1.26.8
 whitenoise==6.0.0
 zipp==3.7.0
+requests-cache==0.9.3

--- a/servers/models.py
+++ b/servers/models.py
@@ -2,8 +2,11 @@ from typing import Dict
 from django.db import models
 from requests.auth import HTTPBasicAuth
 import requests
+import requests_cache
 
 STR_MAX_LENGTH = 512
+
+requests_cache.install_cache(expire_after=180)  # Cache GET and HEAD results for 180 seconds
 
 
 class Server(models.Model):


### PR DESCRIPTION
### Overview
* Use [requests-cache] following this [guide](https://realpython.com/caching-external-api-requests/#:~:text=To%20implement%20caching%2C%20we%20can,it%20with%20the%20requests%20package.)
* Delegate backend to requests-cache
  * Locally it'll spawn a sqlite file but on heroku it'll use [in-memory storage](https://requests-cache.readthedocs.io/en/stable/user_guide/backends.html#:~:text=In%20the%20rare%20case%20that%20SQLite%20is%20not%20available%20(for%20example%2C%20on%20Heroku)%2C%20a%20non%2Dpersistent%20in%2Dmemory%20cache%20is%20used%20by%20default.)

| first request | second request |
| --- | --- |
| <img width="415" alt="Screen Shot 2022-04-01 at 11 19 48 PM" src="https://user-images.githubusercontent.com/43416725/161368493-3e01b61e-8f8c-423d-b2bf-1e36fcfe637e.png"> | <img width="406" alt="Screen Shot 2022-04-01 at 11 21 17 PM" src="https://user-images.githubusercontent.com/43416725/161368494-16783c0f-e094-4ab9-8cef-0769128cd02f.png"> |

