### PR TITLE
Add GitHub Activity to My Profile

### DIFF
--- a/auth_provider/templates/profile/my_profile.html
+++ b/auth_provider/templates/profile/my_profile.html
@@ -13,7 +13,8 @@
     <p>GitHub activity in the last 90 days.</p>
     {% if github_activity %}
       <ul>
-        <li>Pull Requests: {{ github_activity }}</li>
+        <li>Pull Requests: {{ github_activity.pull_requests }}</li>
+        <li>Commits: {{ github_activity.commits }}</li>
       </ul>
     {% else %}
       <p>GitHub activity could not be loaded.</p>

--- a/auth_provider/templates/profile/my_profile.html
+++ b/auth_provider/templates/profile/my_profile.html
@@ -1,44 +1,52 @@
-{% extends "base.html" %} {% block content %}
-<style>
-  img {
-    max-width: 250px;
-    border-radius: 50%;
-  }
-</style>
-<div class="card">
-  {% include 'profile/partials/_summary.html' %}
-
-  <section id="github-activity">
-    <h3>GitHub Activity</h3>
-    <p>GitHub activity in the last 90 days.</p>
-    {% if github_activity %}
-      <ul>
-        <li>Pull Requests: {{ github_activity.pull_requests }}</li>
-        <li>Commits: {{ github_activity.commits }}</li>
-      </ul>
-    {% else %}
-      <p>GitHub activity could not be loaded.</p>
-    {% endif %}
-  </section>
-
-  <section id="manage">
-    <h3>Manage</h3>
-    <ul>
-      <li>
-        <a href="{% url 'auth_provider:edit_profile' %}">Edit Profile</a>
-      </li>
-    </ul>
-  </section>
-
-  <section id="resources">
-    <h3>My Resources</h3>
-    <ul>
-      {% for user_resource in user_resources %}
-      <li>
-        <a href="{{ user_resource.link }}">{{ user_resource.name }}</a>
-      </li>
-      {% endfor %}
-    </ul>
-  </section>
-</div>
+{% extends "base.html" %}
+{% block content %}
+    <style>
+		img.profile-pic {
+			max-width: 250px;
+			border-radius: 50%;
+		}
+    </style>
+    <div class="card">
+        {% include 'profile/partials/_summary.html' %}
+        <section id="github-activity">
+            <h3>GitHub Activity</h3>
+            {% if github_activity %}
+                <img src="https://ghchart.rshah.org/{{ github_activity.username }}"
+                     width="100%"
+                     height="auto"
+                     alt="GitHub contribution graph"/>
+                <p>
+                    GitHub activity in the last 90 days
+                </p>
+                <ul>
+                    <li>Commits: {{ github_activity.commits }}</li>
+                    <li>Pull Requests: {{ github_activity.pull_requests }}</li>
+                    <li>Reviews: {{ github_activity.reviews }}</li>
+                    <li>Issues Opened: {{ github_activity.issues }}</li>
+                </ul>
+            {% else %}
+                <p>
+                    GitHub activity could not be loaded.
+                </p>
+            {% endif %}
+        </section>
+        <section id="manage">
+            <h3>Manage</h3>
+            <ul>
+                <li>
+                    <a href="{% url 'auth_provider:edit_profile' %}">Edit Profile</a>
+                </li>
+            </ul>
+        </section>
+        <section id="resources">
+            <h3>My Resources</h3>
+            <ul>
+                {% for user_resource in user_resources %}
+                    <li>
+                        <a href="{{ user_resource.link }}">{{ user_resource.name }}</a>
+                    </li>
+                {% endfor %}
+            </ul>
+        </section>
+    </div>
 {% endblock content %}

--- a/auth_provider/templates/profile/my_profile.html
+++ b/auth_provider/templates/profile/my_profile.html
@@ -8,6 +8,18 @@
 <div class="card">
   {% include 'profile/partials/_summary.html' %}
 
+  <section id="github-activity">
+    <h3>GitHub Activity</h3>
+    <p>GitHub activity in the last 90 days.</p>
+    {% if github_activity %}
+      <ul>
+        <li>Pull Requests: {{ github_activity }}</li>
+      </ul>
+    {% else %}
+      <p>GitHub activity could not be loaded.</p>
+    {% endif %}
+  </section>
+
   <section id="manage">
     <h3>Manage</h3>
     <ul>
@@ -18,7 +30,7 @@
   </section>
 
   <section id="resources">
-    <h3>My resources</h3>
+    <h3>My Resources</h3>
     <ul>
       {% for user_resource in user_resources %}
       <li>

--- a/auth_provider/templates/profile/partials/_summary.html
+++ b/auth_provider/templates/profile/partials/_summary.html
@@ -1,6 +1,6 @@
 <section id="intro">
     <div class="center">
-        <img id="profilephoto" src="{{ object.profile_image_url }}" alt="profile photo" />
+        <img id="profilephoto" class="profile-pic" src="{{ object.profile_image_url }}" alt="profile photo" />
     </div>
 
     <h1>{{ object.get_full_name }}</h1>

--- a/auth_provider/tests.py
+++ b/auth_provider/tests.py
@@ -2,6 +2,7 @@ from django.http import HttpResponse
 from django.test import TestCase, Client
 from django.urls import reverse_lazy
 from django.contrib.auth import get_user_model
+from api.tests.test_api import TEST_PASSWORD, TEST_USERNAME
 
 
 class ViewsTests(TestCase):
@@ -63,3 +64,19 @@ class ViewsTests(TestCase):
         res = self.client.post(reverse_lazy('auth_provider:login'), data=login_data)
         self.assertEqual(res.status_code, 200)
         self.assertContains(res, 'error')
+
+
+class ProfileTests(TestCase):
+    def setUp(self) -> None:
+        self.client = Client()
+        self.user = get_user_model().objects.create_user(username=TEST_USERNAME, password=TEST_PASSWORD)
+        self.user.first_name = 'Bob'
+        self.user.last_name = 'Doyle'
+        self.user.github_url = 'https://www.github.com/reillykeele'
+        self.user.save()
+
+    def test_my_profile(self):
+        self.client.login(username=TEST_USERNAME, password=TEST_PASSWORD)
+        res = self.client.get(reverse_lazy('auth_provider:my_profile'))
+        self.assertEqual(res.status_code, 200)
+        self.assertTemplateUsed(res, 'profile/my_profile.html')

--- a/auth_provider/views.py
+++ b/auth_provider/views.py
@@ -43,14 +43,15 @@ class MyProfileView(DetailView):
             return requests.get(
                 f'https://api.github.com/users/{user}/events?accept=application/vnd.github.v3+json&per_page=100&page={page}')
 
-        page = 1
-        # activity = []
-        activity = 0
+        page = 1        
+        activity = {
+            'pull_requests': 0,
+            'commits': 0
+        }
         while True:
             github_activity_request = send_get_github_activity(user, page)            
             if github_activity_request.status_code == 200:
-                # activity.append(self.parse_github_activity(github_activity_request.json))
-                activity += self.parse_github_activity(github_activity_request.json())
+                self.parse_github_activity(activity, github_activity_request.json())
             else:
                 print('GitHub activity request failed with code ' + github_activity_request.status_code)
                 break
@@ -62,12 +63,12 @@ class MyProfileView(DetailView):
 
         return activity
 
-    def parse_github_activity(self, json: dict):
-        count = 0
+    def parse_github_activity(self, activity: dict, json: dict):        
         for event in json:
             if event['type'] == GitHub_EventType.PullRequestEvent:
-                count += 1        
-        return count
+                activity['pull_requests'] += 1
+            if event['type'] == GitHub_EventType.PushEvent:
+                activity['commits'] += event['payload']['distinct_size']        
 
 
 class ProfileView(DetailView):

--- a/auth_provider/views.py
+++ b/auth_provider/views.py
@@ -31,8 +31,7 @@ class MyProfileView(DetailView):
         context = super().get_context_data(**kwargs)
 
         github_username = get_github_user_from_url(self.object.github_url)
-        if github_username:
-            print(github_username)
+        if github_username:            
             context['github_activity'] = self.get_github_activity(github_username)
 
         context['user_resources'] = [{'name': user_resource[0], 'link': user_resource[1]}
@@ -53,10 +52,10 @@ class MyProfileView(DetailView):
                 # activity.append(self.parse_github_activity(github_activity_request.json))
                 activity += self.parse_github_activity(github_activity_request.json())
             else:
-                print('request failed with code ' + github_activity_request.status_code)
+                print('GitHub activity request failed with code ' + github_activity_request.status_code)
                 break
 
-            if 'rel="next"' in github_activity_request.headers['Link']:
+            if 'Link' in github_activity_request.headers and 'rel="next"' in github_activity_request.headers['Link']:
                 page += 1
             else:
                 break

--- a/auth_provider/views.py
+++ b/auth_provider/views.py
@@ -65,7 +65,7 @@ class MyProfileView(DetailView):
 
     def parse_github_activity(self, activity: dict, json: dict):        
         for event in json:
-            if event['type'] == GitHub_EventType.PullRequestEvent:
+            if event['type'] == GitHub_EventType.PullRequestEvent and event['payload']['action'] == 'closed':
                 activity['pull_requests'] += 1
             if event['type'] == GitHub_EventType.PushEvent:
                 activity['commits'] += event['payload']['distinct_size']        

--- a/lib/constants.py
+++ b/lib/constants.py
@@ -1,0 +1,18 @@
+# https://docs.github.com/en/developers/webhooks-and-events/events/github-event-types
+class GitHub_EventType:
+    CommitCommentEvent = 'CommitCommentEvent'
+    CreateEvent = 'CreateEvent'
+    DeleteEvent = 'DeleteEvent'
+    ForkEvent = 'ForkEvent'
+    GollumEvent = 'GollumEvent'
+    IssueCommentEvent = 'IssueCommentEvent'
+    IssuesEvent = 'IssuesEvent'
+    MemberEvent = 'MemberEvent'
+    PublicEvent = 'PublicEvent'
+    PullRequestEvent = 'PullRequestEvent'
+    PullRequestReviewEvent = 'PullRequestReviewEvent'
+    PullRequestReviewCommentEvent = 'PullRequestReviewCommentEvent'
+    PushEvent = 'PushEvent'
+    ReleaseEvent = 'ReleaseEvent'
+    SponsorshipEvent = 'SponsorshipEvent'
+    WatchEvent = 'WatchEvent'

--- a/lib/url.py
+++ b/lib/url.py
@@ -37,9 +37,10 @@ def is_url_valid_image(url: str) -> bool:
 
     return False
 
+
 def get_github_user_from_url(url: str):
     parsed_url = parse.urlparse(url)
     if parsed_url.scheme == 'http' or parsed_url.scheme == 'https':
-        if 'github' in parsed_url.hostname and parsed_url.path:        
+        if 'github' in parsed_url.hostname and parsed_url.path:
             return parsed_url.path.strip('/')
     return None

--- a/lib/url.py
+++ b/lib/url.py
@@ -5,6 +5,8 @@ import requests
 
 import mimetypes
 
+from urllib import parse
+
 
 def is_url_valid(url: str) -> bool:
     validate = URLValidator()
@@ -34,3 +36,10 @@ def is_url_valid_image(url: str) -> bool:
         return get.headers.get('content-type').startswith('image')
 
     return False
+
+def get_github_user_from_url(url: str):
+    parsed_url = parse.urlparse(url)
+    if parsed_url.scheme == 'http' or parsed_url.scheme == 'https':
+        if 'github' in parsed_url.hostname and parsed_url.path:        
+            return parsed_url.path.strip('/')
+    return None


### PR DESCRIPTION
### Overview
- Adds a "GitHub Activity" section to the "My Profile" screen
    - I know the user story says "As an author, I want to pull in my github activity to my “stream"", but it doesn't really make any sense with our app in my opinion. 
    - Further, it only says _my_ activity, which is why this is in the "My Profile". That said, it can easily be moved. 
    - It would also be extremely easy to add this for _all_ profiles
- We query against the GitHub Events API and parse the information to assess the following:
    - This could potentially be changed in the future to use the [GitHub API V4 with GraphQL](https://docs.github.com/en/graphql/reference/objects#contributionscollection)
    - Access the graph from `https://ghchart.rshah.org/{username}`

A successful profile where there is information to display:
![image](https://user-images.githubusercontent.com/54957139/161411073-60eb5bf6-1d7f-4286-8aed-e114ff1e4581.png)

If the GitHub profile is invalid, or the username cannot be parsed from `github_url`:
![image](https://user-images.githubusercontent.com/54957139/161411122-c3950c53-4957-49a7-aeb8-58752ac75de6.png)

Closes #18 