### PR TITLE
Wrap up remaining POST endpoints

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -77,6 +77,11 @@ class PostSerializer(NestedHyperlinkedModelSerializer):
         representation['id'] = representation['source']
         return representation
 
+    def to_internal_value(self, data):
+        internal_value = super().to_internal_value(data)
+        internal_value['author_id'] = data['author_id']
+        return internal_value
+
 
 class FollowersSerializer(NestedHyperlinkedModelSerializer):
     parent_lookup_kwargs = {

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -151,7 +151,7 @@ class RemoteLikeSerializer(serializers.ModelSerializer):
             parsed_server_service_address = urlparse(server.service_address)
             if parsed_author_url.hostname != parsed_server_service_address.hostname:
                 continue
-            author: Response = server.get(parsed_server_service_address.path)
+            author: Response = server.get(parsed_author_url.path)
             json_author = author.json()
 
             author_name = json_author.get('displayName') or json_author.get('display_name') or ''

--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -207,6 +207,15 @@ class PostTests(TestCase):
         with self.assertRaises(Post.DoesNotExist):
             Post.objects.get(pk=post.id)
 
+    def test_remote_destroy(self):    
+        api_user_username = 'api_user'
+        api_user = get_user_model().objects.create_user(username=api_user_username, password=TEST_PASSWORD)
+        api_user.is_api_user = True
+        api_user.save()
+
+        self.client.login(username=api_user_username, password=TEST_PASSWORD)
+        res = self.client.delete(f'/api/v1/authors/{self.user.id}/posts/{self.post.id}')
+        self.assertEqual(res.status_code, 403)
 
 class CommentsTests(TestCase):
     def setUp(self) -> None:

--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -175,7 +175,7 @@ class PostTests(TestCase):
         initial_post_count = len(Post.objects.filter(author=self.user))
         payload = POST_DATA
         res = self.client.post(f'/api/v1/authors/{self.user.id}/posts/', payload)
-        self.assertTrue(res.status_code >= 200 and res.status_code < 300)
+        self.assertEqual(res.status_code, 201)
         self.assertTrue(len(Post.objects.filter(author=self.user)), initial_post_count + 1)
 
 
@@ -188,6 +188,24 @@ class PostTests(TestCase):
         self.client.login(username=api_user_username, password=TEST_PASSWORD)
         res = self.client.post(f'/api/v1/authors/{self.user.id}/posts/')
         self.assertEqual(res.status_code, 403)
+    
+    def test_destroy(self):
+        self.client.login(username=TEST_USERNAME, password=TEST_PASSWORD)
+
+        post = Post.objects.create(
+            title=POST_DATA['title'],
+            description=POST_DATA['description'],
+            content_type=POST_DATA['content_type'],
+            content=POST_DATA['content'],
+            author_id=self.user.id,
+            unlisted=POST_DATA['unlisted'])
+        post.save()
+
+        res = self.client.delete(f'/api/v1/authors/{self.user.id}/posts/{post.id}')
+        self.assertEqual(res.status_code, 204)
+
+        with self.assertRaises(Post.DoesNotExist):
+            Post.objects.get(pk=post.id)
 
 
 class CommentsTests(TestCase):

--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -236,6 +236,29 @@ class PostTests(TestCase):
 
         self.assertEqual(Post.objects.get(pk=post.id).title, new_title)
 
+    def test_remote_update(self):
+        post = Post.objects.create(
+                    title=POST_DATA['title'],
+                    description=POST_DATA['description'],
+                    content_type=POST_DATA['content_type'],
+                    content=POST_DATA['content'],
+                    author_id=self.user.id,
+                    unlisted=POST_DATA['unlisted'])
+
+        api_user_username = 'api_user'
+        api_user = get_user_model().objects.create_user(username=api_user_username, password=TEST_PASSWORD)
+        api_user.is_api_user = True
+        api_user.save()
+
+        self.client.login(username=api_user_username, password=TEST_PASSWORD)
+
+        payload = POST_DATA
+        new_title = 'This is a new title'
+        payload['title'] = new_title
+        res = self.client.put(f'/api/v1/authors/{self.user.id}/posts/{post.id}/', json.dumps(payload), content_type='application/json')
+        self.assertEqual(res.status_code, 403)
+
+
 class CommentsTests(TestCase):
     def setUp(self) -> None:
         self.client = Client()

--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -178,7 +178,6 @@ class PostTests(TestCase):
         self.assertEqual(res.status_code, 201)
         self.assertTrue(len(Post.objects.filter(author=self.user)), initial_post_count + 1)
 
-
     def test_remote_create(self):
         api_user_username = 'api_user'
         api_user = get_user_model().objects.create_user(username=api_user_username, password=TEST_PASSWORD)
@@ -188,7 +187,7 @@ class PostTests(TestCase):
         self.client.login(username=api_user_username, password=TEST_PASSWORD)
         res = self.client.post(f'/api/v1/authors/{self.user.id}/posts/')
         self.assertEqual(res.status_code, 403)
-    
+
     def test_destroy(self):
         self.client.login(username=TEST_USERNAME, password=TEST_PASSWORD)
 
@@ -207,7 +206,7 @@ class PostTests(TestCase):
         with self.assertRaises(Post.DoesNotExist):
             Post.objects.get(pk=post.id)
 
-    def test_remote_destroy(self):    
+    def test_remote_destroy(self):
         api_user_username = 'api_user'
         api_user = get_user_model().objects.create_user(username=api_user_username, password=TEST_PASSWORD)
         api_user.is_api_user = True
@@ -219,31 +218,34 @@ class PostTests(TestCase):
 
     def test_put_update(self):
         post = Post.objects.create(
-                    title=POST_DATA['title'],
-                    description=POST_DATA['description'],
-                    content_type=POST_DATA['content_type'],
-                    content=POST_DATA['content'],
-                    author_id=self.user.id,
-                    unlisted=POST_DATA['unlisted'])
+            title=POST_DATA['title'],
+            description=POST_DATA['description'],
+            content_type=POST_DATA['content_type'],
+            content=POST_DATA['content'],
+            author_id=self.user.id,
+            unlisted=POST_DATA['unlisted'])
 
         self.client.login(username=TEST_USERNAME, password=TEST_PASSWORD)
 
         payload = POST_DATA
         new_title = 'This is a new title'
         payload['title'] = new_title
-        res = self.client.put(f'/api/v1/authors/{self.user.id}/posts/{post.id}/', json.dumps(payload), content_type='application/json')
+        res = self.client.put(
+            f'/api/v1/authors/{self.user.id}/posts/{post.id}/',
+            json.dumps(payload),
+            content_type='application/json')
         self.assertEqual(res.status_code, 200)
 
         self.assertEqual(Post.objects.get(pk=post.id).title, new_title)
 
     def test_remote_update(self):
         post = Post.objects.create(
-                    title=POST_DATA['title'],
-                    description=POST_DATA['description'],
-                    content_type=POST_DATA['content_type'],
-                    content=POST_DATA['content'],
-                    author_id=self.user.id,
-                    unlisted=POST_DATA['unlisted'])
+            title=POST_DATA['title'],
+            description=POST_DATA['description'],
+            content_type=POST_DATA['content_type'],
+            content=POST_DATA['content'],
+            author_id=self.user.id,
+            unlisted=POST_DATA['unlisted'])
 
         api_user_username = 'api_user'
         api_user = get_user_model().objects.create_user(username=api_user_username, password=TEST_PASSWORD)
@@ -255,7 +257,10 @@ class PostTests(TestCase):
         payload = POST_DATA
         new_title = 'This is a new title'
         payload['title'] = new_title
-        res = self.client.put(f'/api/v1/authors/{self.user.id}/posts/{post.id}/', json.dumps(payload), content_type='application/json')
+        res = self.client.put(
+            f'/api/v1/authors/{self.user.id}/posts/{post.id}/',
+            json.dumps(payload),
+            content_type='application/json')
         self.assertEqual(res.status_code, 403)
 
 

--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -217,6 +217,25 @@ class PostTests(TestCase):
         res = self.client.delete(f'/api/v1/authors/{self.user.id}/posts/{self.post.id}')
         self.assertEqual(res.status_code, 403)
 
+    def test_put_update(self):
+        post = Post.objects.create(
+                    title=POST_DATA['title'],
+                    description=POST_DATA['description'],
+                    content_type=POST_DATA['content_type'],
+                    content=POST_DATA['content'],
+                    author_id=self.user.id,
+                    unlisted=POST_DATA['unlisted'])
+
+        self.client.login(username=TEST_USERNAME, password=TEST_PASSWORD)
+
+        payload = POST_DATA
+        new_title = 'This is a new title'
+        payload['title'] = new_title
+        res = self.client.put(f'/api/v1/authors/{self.user.id}/posts/{post.id}/', json.dumps(payload), content_type='application/json')
+        self.assertEqual(res.status_code, 200)
+
+        self.assertEqual(Post.objects.get(pk=post.id).title, new_title)
+
 class CommentsTests(TestCase):
     def setUp(self) -> None:
         self.client = Client()

--- a/api/views.py
+++ b/api/views.py
@@ -188,7 +188,7 @@ class LikedViewSet(viewsets.ModelViewSet):
     http_method_names = ['get']
 
     def get_queryset(self):
-        return Like.objects.filter(author_id=self.kwargs['author_pk'])
+        return Like.objects.filter(author_id=self.kwargs['author_pk']).order_by('author_id')
 
 
 class CommentViewSet(viewsets.ModelViewSet):
@@ -212,7 +212,7 @@ class CommentLikesViewSet(viewsets.ModelViewSet):
     http_method_names = ['get']
 
     def get_queryset(self):
-        return Comment.objects.get(pk=self.kwargs['comment_pk']).commentlike_set.all()
+        return Comment.objects.get(pk=self.kwargs['comment_pk']).commentlike_set.all().order_by('author_id')
 
 
 def handle_inbox_like(request: Request, body: dict[str, Any]) -> Response:

--- a/api/views.py
+++ b/api/views.py
@@ -111,7 +111,9 @@ class PostViewSet(viewsets.ModelViewSet):
         if request.user.is_api_user:
             raise PermissionDenied(detail='No access to local objects', code=status.HTTP_403_FORBIDDEN)
         if request.user.id != int(kwargs['author_pk']):
-            raise PermissionDenied(detail='Cannot create post on behalf of another user', code=status.HTTP_403_FORBIDDEN)
+            raise PermissionDenied(
+                detail='Cannot create post on behalf of another user',
+                code=status.HTTP_403_FORBIDDEN)
         # https://stackoverflow.com/questions/44717442/this-querydict-instance-is-immutable
         request.data._mutable = True
         request.data['author_id'] = kwargs['author_pk']
@@ -122,14 +124,18 @@ class PostViewSet(viewsets.ModelViewSet):
         if request.user.is_api_user:
             raise PermissionDenied(detail='No access to local objects', code=status.HTTP_403_FORBIDDEN)
         if request.user.id != int(kwargs['author_pk']):
-            raise PermissionDenied(detail='Cannot delete post on behalf of another user', code=status.HTTP_403_FORBIDDEN)
+            raise PermissionDenied(
+                detail='Cannot delete post on behalf of another user',
+                code=status.HTTP_403_FORBIDDEN)
         return super().destroy(request, *args, **kwargs)
 
     def update(self, request, *args, **kwargs):
         if request.user.is_api_user:
             raise PermissionDenied(detail='No access to local objects', code=status.HTTP_403_FORBIDDEN)
         if request.user.id != int(kwargs['author_pk']):
-            raise PermissionDenied(detail='Cannot update post on behalf of another user', code=status.HTTP_403_FORBIDDEN)
+            raise PermissionDenied(
+                detail='Cannot update post on behalf of another user',
+                code=status.HTTP_403_FORBIDDEN)
         request.data['author_id'] = kwargs['author_pk']
         return super().update(request, *args, **kwargs)
 

--- a/api/views.py
+++ b/api/views.py
@@ -86,7 +86,7 @@ class PostViewSet(viewsets.ModelViewSet):
 
     serializer_class = PostSerializer
     permission_classes = [permissions.IsAuthenticated]
-    http_method_names = ['get', 'post', 'delete']
+    http_method_names = ['get', 'post', 'delete', 'put']
 
     def get_queryset(self):
         return Post.objects.filter(author=self.kwargs['author_pk']).order_by('-date_published')
@@ -117,12 +117,21 @@ class PostViewSet(viewsets.ModelViewSet):
         request.data['author_id'] = kwargs['author_pk']
         request.data._mutable = False
         return super().create(request, *args, **kwargs)
+
     def destroy(self, request, *args, **kwargs):
         if request.user.is_api_user:
             raise PermissionDenied(detail='No access to local objects', code=status.HTTP_403_FORBIDDEN)
         if request.user.id != int(kwargs['author_pk']):
             raise PermissionDenied(detail='Cannot delete post on behalf of another user', code=status.HTTP_403_FORBIDDEN)
         return super().destroy(request, *args, **kwargs)
+
+    def update(self, request, *args, **kwargs):
+        if request.user.is_api_user:
+            raise PermissionDenied(detail='No access to local objects', code=status.HTTP_403_FORBIDDEN)
+        if request.user.id != int(kwargs['author_pk']):
+            raise PermissionDenied(detail='Cannot update post on behalf of another user', code=status.HTTP_403_FORBIDDEN)
+        request.data['author_id'] = kwargs['author_pk']
+        return super().update(request, *args, **kwargs)
 
 
 class FollowersViewSet(viewsets.ModelViewSet):

--- a/api/views.py
+++ b/api/views.py
@@ -86,7 +86,7 @@ class PostViewSet(viewsets.ModelViewSet):
 
     serializer_class = PostSerializer
     permission_classes = [permissions.IsAuthenticated]
-    http_method_names = ['get', 'post']
+    http_method_names = ['get', 'post', 'delete']
 
     def get_queryset(self):
         return Post.objects.filter(author=self.kwargs['author_pk']).order_by('-date_published')
@@ -117,6 +117,12 @@ class PostViewSet(viewsets.ModelViewSet):
         request.data['author_id'] = kwargs['author_pk']
         request.data._mutable = False
         return super().create(request, *args, **kwargs)
+    def destroy(self, request, *args, **kwargs):
+        if request.user.is_api_user:
+            raise PermissionDenied(detail='No access to local objects', code=status.HTTP_403_FORBIDDEN)
+        if request.user.id != int(kwargs['author_pk']):
+            raise PermissionDenied(detail='Cannot delete post on behalf of another user', code=status.HTTP_403_FORBIDDEN)
+        return super().destroy(request, *args, **kwargs)
 
 
 class FollowersViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
### Overview
* Add POST `/posts/{post_id}`
* Add DELETE `/posts/{post_id}`
* Add PUT `/posts/{post_id}`
* Add POST `/posts/

### TODO
* Test create images

### Caveats
* Unfortunately I can't implement POST for update cleanly (drf marks it as unallowed, and it seems like an antipattern for them [source](https://stackoverflow.com/questions/37833307/django-rest-framework-post-update-if-existing-or-create))
  * I might have to use a generic API in the near future

### Notes
* Also fixes bug for remote like

Closes #88 