### PR TITLE
Secure edit post page

### DIFF
--- a/posts/tests/test_views.py
+++ b/posts/tests/test_views.py
@@ -95,6 +95,24 @@ class EditPostViewTests(TestCase):
         self.client.login(username='bob', password='password')
         res = self.client.post(reverse('posts:edit', kwargs={'pk': 900}), data=EDITED_POST_DATA)
         self.assertEqual(res.status_code, 404)
+    
+    def test_edit_page_as_another_user(self):
+        username = 'alice'
+        password = TEST_PASSWORD
+        get_user_model().objects.create_user(username=username, password=password)
+
+        self.client.login(username=username, password=password)
+        res = self.client.get(reverse('posts:edit', kwargs={'pk': self.post_id}))
+        self.assertEqual(res.status_code, 403)
+
+    def test_edit_as_another_user(self):
+        username = 'alice'
+        password = TEST_PASSWORD
+        get_user_model().objects.create_user(username=username, password=password)
+
+        self.client.login(username=username, password=password)
+        res = self.client.post(reverse('posts:edit', kwargs={'pk': self.post_id}), data=EDITED_POST_DATA)
+        self.assertEqual(res.status_code, 403)
 
 
 class PostDetailViewTests(TestCase):

--- a/posts/tests/test_views.py
+++ b/posts/tests/test_views.py
@@ -95,7 +95,7 @@ class EditPostViewTests(TestCase):
         self.client.login(username='bob', password='password')
         res = self.client.post(reverse('posts:edit', kwargs={'pk': 900}), data=EDITED_POST_DATA)
         self.assertEqual(res.status_code, 404)
-    
+
     def test_edit_page_as_another_user(self):
         username = 'alice'
         password = TEST_PASSWORD

--- a/posts/views.py
+++ b/posts/views.py
@@ -12,6 +12,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.urls import reverse_lazy
 from requests import Response
 from lib.http_helper import is_b64_image_content
+from django.core.exceptions import PermissionDenied
 
 from .models import CommentLike, Post, Category, Comment, Like
 from servers.models import Server
@@ -63,6 +64,15 @@ class EditPostView(LoginRequiredMixin, UpdateView):
             form.save()
         return redirect(form.instance.get_absolute_url())
 
+    def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
+        if self.get_object().author_id != request.user.id:
+            raise PermissionDenied("User not allowed to edit another user's post")
+        return super().get(request, *args, **kwargs)
+
+    def post(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
+        if self.get_object().author_id != request.user.id:
+            raise PermissionDenied("User not allowed to edit another user's post")
+        return super().post(request, *args, **kwargs)
 
 class PostDetailView(LoginRequiredMixin, DetailView):
     model = Post

--- a/posts/views.py
+++ b/posts/views.py
@@ -74,6 +74,7 @@ class EditPostView(LoginRequiredMixin, UpdateView):
             raise PermissionDenied("User not allowed to edit another user's post")
         return super().post(request, *args, **kwargs)
 
+
 class PostDetailView(LoginRequiredMixin, DetailView):
     model = Post
 


### PR DESCRIPTION
### Overview
* Prevent other users from editing your post through the location bar (i.e. `/posts/{post_id_of_another_user}/edit`

Closes #33