### PR TITLE
Fix Miscellaneous Bug and Add Ehancements

### DIFF
--- a/auth_provider/templates/profile/my_profile.html
+++ b/auth_provider/templates/profile/my_profile.html
@@ -7,29 +7,7 @@
 		}
     </style>
     <div class="card">
-        {% include 'profile/partials/_summary.html' %}
-        <section id="github-activity">
-            <h3>GitHub Activity</h3>
-            {% if github_activity %}
-                <img src="https://ghchart.rshah.org/{{ github_activity.username }}"
-                     width="100%"
-                     height="auto"
-                     alt="GitHub contribution graph"/>
-                <p>
-                    GitHub activity in the last 90 days
-                </p>
-                <ul>
-                    <li>Commits: {{ github_activity.commits }}</li>
-                    <li>Pull Requests: {{ github_activity.pull_requests }}</li>
-                    <li>Reviews: {{ github_activity.reviews }}</li>
-                    <li>Issues Opened: {{ github_activity.issues }}</li>
-                </ul>
-            {% else %}
-                <p>
-                    GitHub activity could not be loaded.
-                </p>
-            {% endif %}
-        </section>
+        {% include 'profile/partials/_summary.html' %}        
         <section id="manage">
             <h3>Manage</h3>
             <ul>

--- a/auth_provider/templates/profile/partials/_summary.html
+++ b/auth_provider/templates/profile/partials/_summary.html
@@ -1,9 +1,30 @@
 <section id="intro">
     <div class="center">
-        <img id="profilephoto" class="profile-pic" src="{{ object.profile_image_url }}" alt="profile photo" />
+        <img id="profilephoto"
+             class="profile-pic"
+             src="{{ object.profile_image_url }}"
+             alt="profile photo"
+             onerror="this.src='/static/default.jpg'"/>
     </div>
-
     <h1>{{ object.get_full_name }}</h1>
     <h2 class="subtitle">{{ object.username }}</h2>
-    <span><a href="{{ object.github_url }}">Github profile</a></span>
+    <span><a href="{{ object.github_url }}">GitHub profile</a></span>
 </section>
+{% if github_activity %}
+    <section id="github-activity">
+        <h3>GitHub Activity</h3>
+        <img src="https://ghchart.rshah.org/{{ github_activity.username }}"
+             width="100%"
+             height="auto"
+             alt="GitHub contribution graph"/>
+        <p>
+            GitHub activity in the last 90 days
+        </p>
+        <ul>
+            <li>Commits: {{ github_activity.commits }}</li>
+            <li>Pull Requests: {{ github_activity.pull_requests }}</li>
+            <li>Reviews: {{ github_activity.reviews }}</li>
+            <li>Issues Opened: {{ github_activity.issues }}</li>
+        </ul>
+    </section>
+{% endif %}

--- a/auth_provider/templates/profile/partials/_summary.html
+++ b/auth_provider/templates/profile/partials/_summary.html
@@ -8,7 +8,7 @@
     </div>
     <h1>{{ object.get_full_name }}</h1>
     <h2 class="subtitle">{{ object.username }}</h2>
-    <span><a href="{{ object.github_url }}">GitHub profile</a></span>
+    <span><a href="{{ object.github_url }}">GitHub Profile</a></span>
 </section>
 {% if github_activity %}
     <section id="github-activity">

--- a/auth_provider/templates/profile/remote_user_profile.html
+++ b/auth_provider/templates/profile/remote_user_profile.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %} {% block content %}
 <style>
-  img {
-    max-width: 250px;
-    border-radius: 50%;
-  }
+  img.profile-pic {
+			max-width: 250px;
+			border-radius: 50%;
+		}
 </style>
 <div class="card">
   {% include 'profile/partials/_summary.html' %}

--- a/auth_provider/templates/profile/remote_user_profile.html
+++ b/auth_provider/templates/profile/remote_user_profile.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %} {% block content %}
 <style>
   img.profile-pic {
-			max-width: 250px;
-			border-radius: 50%;
-		}
+    max-width: 250px;
+    border-radius: 50%;
+  }
 </style>
 <div class="card">
   {% include 'profile/partials/_summary.html' %}

--- a/auth_provider/templates/profile/user_profile.html
+++ b/auth_provider/templates/profile/user_profile.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %} {% block content %}
 <style>
-  img {
-    max-width: 250px;
-    border-radius: 50%;
-  }
+  img.profile-pic {
+			max-width: 250px;
+			border-radius: 50%;
+		}
 </style>
 <div class="card">
   {% include 'profile/partials/_summary.html' %}

--- a/auth_provider/templates/profile/user_profile.html
+++ b/auth_provider/templates/profile/user_profile.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %} {% block content %}
 <style>
   img.profile-pic {
-			max-width: 250px;
-			border-radius: 50%;
-		}
+    max-width: 250px;
+    border-radius: 50%;
+  }
 </style>
 <div class="card">
   {% include 'profile/partials/_summary.html' %}

--- a/auth_provider/views.py
+++ b/auth_provider/views.py
@@ -33,54 +33,10 @@ class MyProfileView(DetailView):
     def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:
         context = super().get_context_data(**kwargs)
 
-        github_username = get_github_user_from_url(self.object.github_url)
-        if github_username:
-            context['github_activity'] = self.get_github_activity(github_username)
-
+        context['github_activity'] = get_github_activity(self.object.github_url)
         context['user_resources'] = [{'name': user_resource[0], 'link': user_resource[1]}
                                      for user_resource in user_resources]
-        return context
-
-    def get_github_activity(self, user: str):
-        def send_get_github_activity(user: str, page: int = 1):
-            return requests.get(
-                f'https://api.github.com/users/{user}/events?accept=application/vnd.github.v3+json&per_page=100&page={page}')
-
-        page = 1
-        activity = {
-            'username': user,
-            'commits': 0,
-            'pull_requests': 0,
-            'reviews': 0,
-            'issues': 0,
-        }
-        success = False
-        while True:
-            github_activity_request = send_get_github_activity(user, page)
-            if github_activity_request.status_code == 200:
-                self.parse_github_activity(activity, github_activity_request.json())
-                success |= True
-            else:
-                print('GitHub activity request failed with code ' + github_activity_request.status_code)
-                break
-
-            if 'Link' in github_activity_request.headers and 'rel="next"' in github_activity_request.headers['Link']:
-                page += 1
-            else:
-                break
-
-        return activity if success else None
-
-    def parse_github_activity(self, activity: dict, json: dict):
-        for event in json:
-            if event['type'] == GitHub_EventType.PushEvent:
-                activity['commits'] += event['payload']['distinct_size']
-            if event['type'] == GitHub_EventType.PullRequestEvent and event['payload']['action'] == 'opened':
-                activity['pull_requests'] += 1
-            if event['type'] == GitHub_EventType.PullRequestReviewEvent:
-                activity['reviews'] += 1
-            if event['type'] == GitHub_EventType.IssuesEvent:
-                activity['issues'] += 1
+        return context    
 
 
 class ProfileView(DetailView):
@@ -102,6 +58,7 @@ class ProfileView(DetailView):
                 'link': user_action[1],
             }
 
+        context['github_activity'] = get_github_activity(self.object.github_url)
         # TODO: Clean this up with a lambda
         actions = [get_action(user_action_generator)
                    for user_action_generator in user_action_generators]
@@ -124,6 +81,7 @@ class RemoteProfileView(ServerDetailView):
         context = super().get_context_data(**kwargs)
 
         # TODO: Get user actions for remote users
+        context['github_activity'] = get_github_activity(self.object['github_url'])
         context['user_actions'] = []
         return context
 
@@ -153,3 +111,48 @@ class EditProfileView(UpdateView):
 def logout_view(request):
     logout(request)
     return redirect('/')
+
+def get_github_activity(github_url: str):
+    github_username = get_github_user_from_url(github_url)
+    if not github_username:
+        return None
+
+    def send_get_github_activity(user: str, page: int = 1):
+        return requests.get(
+            f'https://api.github.com/users/{user}/events?accept=application/vnd.github.v3+json&per_page=100&page={page}')
+
+    page = 1
+    activity = {
+        'username': github_username,
+        'commits': 0,
+        'pull_requests': 0,
+        'reviews': 0,
+        'issues': 0,
+    }
+    success = False
+    while True:
+        github_activity_request = send_get_github_activity(github_username, page)
+        if github_activity_request.status_code == 200:
+            parse_github_activity(activity, github_activity_request.json())
+            success |= True
+        else:
+            print('GitHub activity request failed with code ' + github_activity_request.status_code)
+            break
+
+        if 'Link' in github_activity_request.headers and 'rel="next"' in github_activity_request.headers['Link']:
+            page += 1
+        else:
+            break
+
+    return activity if success else None
+
+def parse_github_activity(activity: dict, json: dict):
+    for event in json:
+        if event['type'] == GitHub_EventType.PushEvent:
+            activity['commits'] += event['payload']['distinct_size']
+        if event['type'] == GitHub_EventType.PullRequestEvent and event['payload']['action'] == 'opened':
+            activity['pull_requests'] += 1
+        if event['type'] == GitHub_EventType.PullRequestReviewEvent:
+            activity['reviews'] += 1
+        if event['type'] == GitHub_EventType.IssuesEvent:
+            activity['issues'] += 1

--- a/auth_provider/views.py
+++ b/auth_provider/views.py
@@ -2,7 +2,7 @@ import requests
 import json
 from typing import Any, Dict, Optional
 from django.shortcuts import redirect
-from django.urls import reverse_lazy
+from django.urls import reverse, reverse_lazy
 from django.contrib.auth import get_user_model, logout
 from django.views.generic.edit import CreateView, UpdateView
 from django.views.generic.detail import DetailView
@@ -106,6 +106,9 @@ class EditProfileView(UpdateView):
 
     def get_object(self):
         return self.request.user
+
+    def get_success_url(self) -> str:
+        return reverse('auth_provider:my_profile')
 
 
 def logout_view(request):

--- a/auth_provider/views.py
+++ b/auth_provider/views.py
@@ -36,7 +36,7 @@ class MyProfileView(DetailView):
         context['github_activity'] = get_github_activity(self.object.github_url)
         context['user_resources'] = [{'name': user_resource[0], 'link': user_resource[1]}
                                      for user_resource in user_resources]
-        return context    
+        return context
 
 
 class ProfileView(DetailView):
@@ -91,11 +91,13 @@ class RemoteProfileView(ServerDetailView):
         profile_image_url = json_response.get('profileImage') or json_response.get('profile_image')
         author_full_name = json_response.get('displayName') or json_response.get('display_name')
         github = json_response.get('github')
+        username = get_github_user_from_url(github)
 
         return {
             'profile_image_url': profile_image_url,
             "get_full_name": author_full_name,
             "github_url": github,
+            "username": username
         }
 
 
@@ -114,6 +116,7 @@ class EditProfileView(UpdateView):
 def logout_view(request):
     logout(request)
     return redirect('/')
+
 
 def get_github_activity(github_url: str):
     github_username = get_github_user_from_url(github_url)
@@ -148,6 +151,7 @@ def get_github_activity(github_url: str):
             break
 
     return activity if success else None
+
 
 def parse_github_activity(activity: dict, json: dict):
     for event in json:

--- a/follow/templates/follow/partials/_user_card.html
+++ b/follow/templates/follow/partials/_user_card.html
@@ -8,8 +8,10 @@
                 onerror="this.src='/static/default.jpg'"/>
         </div>
         <div class="grid-item">
-            <h3>{{ object.get_full_name }}</h3>
-            <h4 class="subtitle">{{ object.username }}</h4>
+            <div>
+                <h3>{{ object.get_full_name }}</h3>
+                <h4 class="subtitle">{{ object.username }}</h4>
+            </div>
         </div>
     </div>
 </a>

--- a/follow/templates/follow/partials/_user_card.html
+++ b/follow/templates/follow/partials/_user_card.html
@@ -1,6 +1,15 @@
 <a href="{{ object.get_absolute_url }}" style="color: inherit">
-    <div class="card interactable">
-        <h3>{{ object.get_full_name }}</h3>
-        <h4 class="subtitle">{{ object.username }}</h4>
+    <div class="card interactable user-card">
+        <div class="grid-item">
+            <img id="profilephoto"
+                class="profile-pic"
+                src="{{ object.profile_image_url }}"
+                alt="profile photo"
+                onerror="this.src='/static/default.jpg'"/>
+        </div>
+        <div class="grid-item">
+            <h3>{{ object.get_full_name }}</h3>
+            <h4 class="subtitle">{{ object.username }}</h4>
+        </div>
     </div>
 </a>

--- a/follow/templates/follow/user_list.html
+++ b/follow/templates/follow/user_list.html
@@ -1,15 +1,24 @@
-{% extends "base.html" %} {% block content %}
+{% extends "base.html" %}
+{% block content %}
+<style>
+div.user-card {
+    display: grid;
+    grid-template-columns: 15% 85%;
+    column-gap: 15px;
+}
+img.profile-pic {
+    width: 100%;
+    border-radius: 50%;
+}
+</style>
 
 <h1>Users</h1>
 
 <ul class="no-indent large-gap">
     {% for object in object_list %}
-    <li>
-        {% include "follow/partials/_user_card.html" %}
-    </li>
+        <li>{% include "follow/partials/_user_card.html" %}</li>
     {% empty %}
-    <li>No one else is here 😢.</li>
+        <li>No one else is here 😢.</li>
     {% endfor %}
 </ul>
-
 {% endblock %}

--- a/follow/templates/follow/user_list.html
+++ b/follow/templates/follow/user_list.html
@@ -4,11 +4,19 @@
 div.user-card {
     display: grid;
     grid-template-columns: 15% 85%;
-    column-gap: 15px;
+    column-gap: 20px;
+    position: relative;
 }
 img.profile-pic {
     width: 100%;
     border-radius: 50%;
+}
+.grid-item div {
+    margin: 0;
+    position: absolute;
+    top: 50%;
+    -ms-transform: translateY(-50%);
+    transform: translateY(-50%);
 }
 </style>
 

--- a/follow/views.py
+++ b/follow/views.py
@@ -87,6 +87,7 @@ class UsersView(LoginRequiredMixin, ServerListView):
         def to_internal(representation: dict[str, Any]):
             return {
                 'get_full_name': representation.get('displayName') or representation.get('display_name'),
+                'profile_image_url': representation.get('profileImage'),
                 'username': representation.get('github'),
                 'get_absolute_url': reverse(
                     'auth_provider:remote_profile',

--- a/follow/views.py
+++ b/follow/views.py
@@ -10,6 +10,7 @@ from django.contrib.auth import get_user_model
 from django.db.models import Q
 from requests import Response
 
+from lib.url import get_github_user_from_url
 from servers.views.generic.list_view import ServerListView
 
 
@@ -88,7 +89,7 @@ class UsersView(LoginRequiredMixin, ServerListView):
             return {
                 'get_full_name': representation.get('displayName') or representation.get('display_name'),
                 'profile_image_url': representation.get('profileImage'),
-                'username': representation.get('github'),
+                'username': get_github_user_from_url(representation.get('github')) or representation.get('github'),
                 'get_absolute_url': reverse(
                     'auth_provider:remote_profile',
                     kwargs={

--- a/posts/templates/posts/partials/_comment.html
+++ b/posts/templates/posts/partials/_comment.html
@@ -1,9 +1,18 @@
+{% load post_tags %}
+
 <div class="comment">
     <a href="{{ comment.author.get_absolute_url }}" style="color:inherit">
         <h4>{{ comment.author.get_full_name }}</h4>
     </a>
     <span>{{ comment.date_published }}</span>
-    <p>{{ comment.comment }}</p>
+    
+    {% if comment.content_type == 'text/plain' %}
+        <p>{{ comment.comment }}</p>
+    {% elif comment.content_type == 'text/markdown' %}
+            <div class='markdown-content'>
+                {{ comment.comment|convert_markdown|safe }}
+            </div>
+    {% endif %}
     <ul class="action-bar">
         <li>
             <form method="POST" action="{% url 'posts:like-comment' comment.post.id comment.id %}">

--- a/posts/views.py
+++ b/posts/views.py
@@ -129,9 +129,7 @@ class RemotePostDetailView(LoginRequiredMixin, ServerDetailView):
                 'content_type': json_body.get('contentType') or json_body.get('content_type'),
                 'date_published': json_body.get('published'),
                 'author': {
-                    'get_full_name': json_body.get('author').get('displayName') or json_body.get('author').get('display_name')
-                }
-            }
+                    'get_full_name': json_body.get('author').get('displayName') or json_body.get('author').get('display_name')}}
 
         comments = []
         try:

--- a/posts/views.py
+++ b/posts/views.py
@@ -126,6 +126,7 @@ class RemotePostDetailView(LoginRequiredMixin, ServerDetailView):
         def to_comments_internal(json_body: Dict[str, Any]):
             return {
                 'comment': json_body.get('comment'),
+                'content_type': json_body.get('contentType') or json_body.get('content_type'),
                 'date_published': json_body.get('published'),
                 'author': {
                     'get_full_name': json_body.get('author').get('displayName') or json_body.get('author').get('display_name')


### PR DESCRIPTION
### Overview
Apologies in advance for the scattered PR. List of changes are as follows: 
- GitHub activity is displayed for all user profiles
    - If the activity fails to be fetched (i.e. invalid GitHub username/account) the section will not be displayed
- Add profile pictures to the user list for all users 
    - Closes #130
- Trim the username displayed in the user list and remote user profile
- When saving the 'Edit Profile' screen, return users to 'My Profile' 
    - Closes #119
- Allow for `text/markdown` comments

### Photos! 
New user list card:
![image](https://user-images.githubusercontent.com/54957139/161482613-a03cdc09-b9f5-4060-8720-789802fcc778.png)

GitHub activity on a remote user, as well as trimmed username:
![image](https://user-images.githubusercontent.com/54957139/161482681-c6bb2623-ea69-478d-801a-77fbf3d5a887.png)

Markdown comment:
![image](https://user-images.githubusercontent.com/54957139/161482474-d9f8ca0b-99fb-4ffb-9e42-4e5fd2fa3745.png)

Verifying remote markdown posts displays correctly: 
![image](https://user-images.githubusercontent.com/54957139/161482224-d121f17e-7f36-4eb5-994c-62b5e29d8814.png)
